### PR TITLE
Simplified Plugin Proxy (Simple Return Type & console.log)

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -264,7 +264,7 @@ const sendPluginQuery = (action: Action, requestArgs: Record<string, unknown>, c
             const { success } = await process.status();
             const { stdout, stderr } = outputAfterResponstStart;
 
-            if (!success) {
+            if (!success || !stdout && stderr) {
                 return Promise.reject({
                     kind: 'E_INVALID_JSON',
                     msg: 'TODO i18n message',

--- a/taqueria-plugin-boilerplate-typescript/index.ts
+++ b/taqueria-plugin-boilerplate-typescript/index.ts
@@ -10,21 +10,8 @@ Plugin.create((i18n: i18n) => ({
         Task.create({
             task: "rickroll",
             command: "rickroll",
-            description: "Generate types for a contract to be used with taquito",
-            options: [
-                Option.create({
-                    shortFlag: "o",
-                    flag: "typescriptDir",
-                    description: "The entry point that will be compiled"
-                }),
-                Option.create({
-                    shortFlag: "t",
-                    flag: "typeAliasMode",
-                    choices: ['file', 'simple'],
-                    description: "The type aliases used in the generated types"
-                }),
-            ],
-            aliases: ["typegen"],
+            description: "This is great!",
+            aliases: ["rr"],
             handler: "proxy"
         }),
     ],

--- a/taqueria-plugin-boilerplate-typescript/index.ts
+++ b/taqueria-plugin-boilerplate-typescript/index.ts
@@ -10,7 +10,14 @@ Plugin.create((i18n: i18n) => ({
         Task.create({
             task: "rickroll",
             command: "rickroll",
-            description: "This is great!",
+            description: "Get your friends!",
+            options: [
+                Option.create({
+                    shortFlag: "t",
+                    flag: "target",
+                    description: "Who is the target?"
+                }),
+            ],
             aliases: ["rr"],
             handler: "proxy"
         }),

--- a/taqueria-plugin-boilerplate-typescript/tasks.ts
+++ b/taqueria-plugin-boilerplate-typescript/tasks.ts
@@ -1,8 +1,14 @@
 import { SanitizedArgs } from "taqueria-sdk/types";
 
-type Opts = SanitizedArgs & Record<string, unknown>;
+type Opts = SanitizedArgs & {
+    target?: string,
+};
 
 export const rickroll = async (parsedArgs: Opts) => {
-    console.log('Please visit: https://youtu.be/dQw4w9WgXcQ');
+    if(!parsedArgs.target){
+        throw new Error('You must specify a target');
+    }
+
+    console.log(`${parsedArgs.target} - Please visit: https://youtu.be/dQw4w9WgXcQ`);
 }
 

--- a/taqueria-plugin-boilerplate-typescript/tasks.ts
+++ b/taqueria-plugin-boilerplate-typescript/tasks.ts
@@ -1,12 +1,8 @@
-import { SanitizedArgs, ActionResponse, Failure, LikeAPromise, ProxyAction } from "taqueria-sdk/types";
+import { SanitizedArgs } from "taqueria-sdk/types";
 
 type Opts = SanitizedArgs & Record<string, unknown>;
 
-export const rickroll = <T>(parsedArgs: Opts): LikeAPromise<ActionResponse, Failure<T>> => {
-    return Promise.resolve({
-        status: 'success',
-        stderr: '',
-        stdout: 'Please visit: https://youtu.be/dQw4w9WgXcQ'
-    });
+export const rickroll = async (parsedArgs: Opts) => {
+    console.log('Please visit: https://youtu.be/dQw4w9WgXcQ');
 }
 

--- a/taqueria-protocol/taqueria-protocol-types.ts
+++ b/taqueria-protocol/taqueria-protocol-types.ts
@@ -191,6 +191,8 @@ export class Scaffold {
 
 export type TaskHandler = "proxy" | string | string[]
 
+// Includes a uuid to prevent possible conflict with normal console messages
+export const TaskResponseStart = '>>> RESPONSE-START 06574a6dead348958605d1f0ec19ba04 <<<'
 
 export interface UnvalidatedTask {
     readonly task: string

--- a/taqueria-sdk/types.ts
+++ b/taqueria-sdk/types.ts
@@ -72,7 +72,7 @@ export interface Schema {
     readonly sandboxes?: (Sandbox | undefined)[]
     checkRuntimeDependencies?: <T>(i18n: i18n, parsedArgs: SanitizedArgs) => LikeAPromise<ActionResponse, Failure<T>>
     installRuntimeDependencies?: <T>(i18n: i18n, parsedargs: SanitizedArgs) => LikeAPromise<ActionResponse, Failure<T>>
-    proxy?: <T>(parsedArgs: SanitizedArgs) => LikeAPromise<ActionResponse, Failure<T>>
+    proxy?: <T>(parsedArgs: SanitizedArgs) => Promise<void> | LikeAPromise<ActionResponse, Failure<T>>
 }
 
 export interface SchemaView {
@@ -86,7 +86,7 @@ export interface SchemaView {
     readonly sandboxes: UnvalidatedSandbox[],
     checkRuntimeDependencies?: <T>(i18n: i18n, parsedArgs: SanitizedArgs) => LikeAPromise<ActionResponse, Failure<T>>
     installRuntimeDependencies?: <T>(i18n: i18n, parsedargs: SanitizedArgs) => LikeAPromise<ActionResponse, Failure<T>>
-    proxy?: <T>(parsedArgs: SanitizedArgs) => LikeAPromise<ActionResponse, Failure<T>>
+    proxy?: <T>(parsedArgs: SanitizedArgs) => Promise<void> | LikeAPromise<ActionResponse, Failure<T>>
 }
 
 export type Args = string[]


### PR DESCRIPTION
- Support console.log, console.error called inside a plugin and pipe directly to console
- Support structured json results (as currently exists)
- Support handling uncaught exceptions from a plugin

Example proxy function for a plugin:

```ts
export const rickroll = async (parsedArgs: Opts) => {
    if(!parsedArgs.target){
        // throw from anywhere
        throw new Error('You must specify a target');
    }

    // console.log anywhere
    console.log(`${parsedArgs.target} - Please visit: https://youtu.be/dQw4w9WgXcQ`);
}
```

Contrast to:

```ts
export const rickroll = (parsedArgs: Opts): LikeAPromise<ActionResponse, Failure<T>> => {
    if(!parsedArgs.target){
        // must return status: failed at proxy root for error state
        return Promise.resolve({
            status: 'failed',
            stderr: 'You must specify a target',
        });
    }

    // must return status: success at proxy root for error state
    return Promise.resolve({
        status: 'success',
        stderr: '',
        stdout: 'Please visit: https://youtu.be/dQw4w9WgXcQ'
    });
}
```
