### PR TITLE
VSCode Extension pipeline for testing, building, and publishing

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -66,7 +66,7 @@ jobs:
           dryRun: true
           packagePath: ${{ env.VSCODE_DIR }}
       - id: setArtifactFilename
-        run: echo "::set-output name=filename::taqueria-vscode-${{ github.head_ref || github.ref_name }}-${{ runner.os }}"
+        run: echo "::set-output name=filename::taqueria-vscode-${{ github.head_ref || github.ref_name }}-${{ runner.os }}.vsix"
       - name: Upload Extension Package as Artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Closes #97 

# Summary
This pipeline lints, builds, and packages the VS Code extension for `taqueria` on every pull request. When a commit is labeled with a Git `tag` the pipeline publishes the extension to the VS Code Marketplace at https://marketplace.visualstudio.com/items?itemName=ecadlabs.taqueria

For now I've omitted `macos` and `windows` from the `lint-test-build` job. Github has usage limits for private repo using publicly hosted runners. I suggest to include `macos` and `windows` once we make the repo public.

# Test Plan 