### PR TITLE
houston-add-markdomn-styling-element example

### DIFF
--- a/website/docs/EXAMPLE_FOR_STYLING.md
+++ b/website/docs/EXAMPLE_FOR_STYLING.md
@@ -1,0 +1,59 @@
+---
+title: Here are some markdown styling elements 
+---
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Markdown Table
+
+| Markdown |      Table    |  XX  |
+|----------|:-------------:|-----:|
+| col 1    |  left-aligned |   y  |
+| col 2    |    centered   |   y  |
+| col 3    | right-aligned |   y  |
+
+
+## Docusaurus Tab Group
+
+<Tabs groupId="operating-systems">
+  <TabItem value="win" label="Windows">Use Ctrl + C to copy.</TabItem>
+  <TabItem value="mac" label="MacOS">Use Command + C to copy.</TabItem>
+</Tabs>
+
+<Tabs groupId="operating-systems">
+  <TabItem value="win" label="Windows">Use Ctrl + V to paste.</TabItem>
+  <TabItem value="mac" label="MacOS">Use Command + V to paste.</TabItem>
+</Tabs>
+
+## Markdown Admonitions
+
+:::note
+
+Some **content** with _markdown_ `syntax`. Check [this `api`](#).
+
+:::
+
+:::tip
+
+Some **content** with _markdown_ `syntax`. Check [this `guide`](#).
+
+:::
+
+:::info
+
+Some **content** with _markdown_ `syntax`. Check [this `reference`](#).
+
+:::
+
+:::caution
+
+Some **content** with _markdown_ `syntax`. Check [this `api`](#).
+
+:::
+
+:::danger
+
+Some **content** with _markdown_ `syntax`. Check [this `api`](#).
+
+:::
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -49,7 +49,9 @@ const sidebars = {
       collapsed: false,
       collapsible: false,
       items: [
-        "hello_tacos"
+        "hello_tacos",
+        "EXAMPLE_FOR_STYLING"
+
       ],
     },
     {


### PR DESCRIPTION
This PR adds the markdown page 'EXAMPLE_FOR_STYLING.md' to the '/website/docs/' folder and adds a reference to the page in the nav bar

This page contains an example of a Table, Tab Group, and list of Admonitions that require styling

JSX elements with inline styling are not a viable solution as they are verbose and don't allow for embedded markdown   