### PR TITLE
Temporarily disable pipelines for MacOS and Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,19 +32,19 @@ jobs:
            os_short: ubuntu
            deno_target: "x86_64-unknown-linux-gnu"
            taqueria_bin: "taqueria"
-         - os: windows-latest
-           os_short: windows
-           deno_target: "x86_64-pc-windows-msvc"
-           taqueria_bin: "taqueria.exe"
-         - os: macOS-latest
-           os_short: macos
-           deno_target: "x86_64-apple-darwin"
-           taqueria_bin: "taqueria"
+        #  - os: windows-latest
+        #    os_short: windows
+        #    deno_target: "x86_64-pc-windows-msvc"
+        #    taqueria_bin: "taqueria.exe"
+        #  - os: macOS-latest
+        #    os_short: macos
+        #    deno_target: "x86_64-apple-darwin"
+        #    taqueria_bin: "taqueria"
 
     outputs:
       public-url-ubuntu: ${{ steps.public-url.outputs.ubuntu }}
-      public-url-windows: ${{ steps.public-url.outputs.windows }}
-      public-url-macos: ${{ steps.public-url.outputs.macos }}
+      # public-url-windows: ${{ steps.public-url.outputs.windows }}
+      # public-url-macos: ${{ steps.public-url.outputs.macos }}
 
     env:
       DENO_TARGET: ${{ matrix.deno_target }}
@@ -167,8 +167,6 @@ jobs:
               | Artifacts |
               | --------- |
               | [Linux](${{ needs.build-and-test.outputs.public-url-ubuntu }}) |
-              | [Windows](${{ needs.build-and-test.outputs.public-url-windows }}) |
-              | [MacOS](${{ needs.build-and-test.outputs.public-url-macos }}) |
             `;
             
             github.rest.issues.createComment({
@@ -230,8 +228,6 @@ jobs:
         run: |
           mkdir release && cd release
           wget ${{ needs.build-and-test.outputs.public-url-ubuntu }} -O taqueria.${GITHUB_REF/refs\/tags\//}-linux
-          wget ${{ needs.build-and-test.outputs.public-url-windows }} -O taqueria.${GITHUB_REF/refs\/tags\//}-windows.exe
-          wget ${{ needs.build-and-test.outputs.public-url-macos }} -O taqueria.${GITHUB_REF/refs\/tags\//}-macos
 
       - name: Release
         id: release


### PR DESCRIPTION
We hit the Github runner limits earlier today. This is mostly caused by workflows running on Windows and MacOS as they have a 2x and 10x usage multiplier compared to workflow running on Linux.

https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers

I propose we avoid running tasks on Windows and MacOS until we publish the repo publicly since runners will be free of use at that point. 