### PR TITLE
Fixes #147, tasks not exposed in cli - among other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,6 @@ I like adding my project directory to the PATH environment variable which allows
 1. Initialize a new project: `taqueria init test-project`
 2. Change directories: `cd test-project`
 3. Initialize the project as an NPM project: `npm init -y`
-4. Install the LIGO plugin: `npm i -D ../taqueria-plugin-ligo`
-5. Activate the LIGO plugin by adding the following to the plugins array in ./.taq/config.json:
-```json
-{
-    "name": "taqueria-plugin-ligo",
-    "type": "npm"
-}
-```
-
-> NOTE: We will be implementing a `taqueria install` task which will do steps 3-5 for you.
+4. Install the LIGO plugin: `taq install ../taqueria-plugin-ligo` if installing from a clone of this repo, otherwise use `taq install @taqueria/plugin-ligo`
 6. Continue steps 4-5 for each additional plugin you want to install
 

--- a/cli.ts
+++ b/cli.ts
@@ -228,7 +228,6 @@ const initProject = (projectDir: SanitizedAbsPath, configDir: SanitizedPath, i18
 )
 
 const getPluginExe = (parsedArgs: SanitizedInitArgs, plugin: InstalledPlugin) => {
-    debugger
     switch(plugin.type) {
         case 'npm':
             const pluginPath = joinPaths(
@@ -311,6 +310,9 @@ const sendPluginQuery = (action: Action, requestArgs: Record<string, unknown>, c
                     // Others need renamed
                     else if (key === '_')
                         return [...retval, '--command', String(val)]
+                    // String types need their values
+                    else if (val instanceof SanitizedAbsPath) 
+                        return [...retval, '--'+key, `'${val.value}'`]
                     // Everything else is good
                     else
                         return [...retval, '--'+key, `'${val}'`]
@@ -549,7 +551,7 @@ const getState = (config: ConfigArgs, env: EnvVars, parsedArgs: SanitizedInitArg
     parsedArgs,
     getStateAbspath,
     (stateAbspath: SanitizedAbsPath) => pipe(
-        debug(!parsedArgs.disableState)
+        !parsedArgs.disableState
             ? resolve(stateAbspath.value)
             : reject("State disabled!"),
         chain (readFile),

--- a/i18n.ts
+++ b/i18n.ts
@@ -15,6 +15,10 @@ await i18next.init({
                 "initDesc": "Initialize a new project",
                 "initPathDesc": "Path to your project directory",
                 "installDesc": "Install a plugin",
+                "pluginInstalled": "Plugin installed successfully",
+                "pluginUninstalled": "Plugin uninstalled successfully",
+                "uninstallDesc": "Uninstall a plugin",
+                "pluginNameDesc": "The name of the plugin",
                 "promptForTask": "Please specify which task you would like to execute. If you're starting a new project, please run 'init'.\n",
                 "pluginKindDesc": "Kind of plugin (NPM, Binary)",
                 "pluginAlreadyInstalled": "That plugin is already installed.",
@@ -24,7 +28,10 @@ await i18next.init({
                 "providedByMany": "Provided by more than one plugin. The option --plugin is required.",
                 "pluginDesc": "Specify what plugin should execute this command. Use this when more than one plugin provide a task of the same name.",
                 "listNetworks": "List known networks",
-                "envDesc": "Specify an environment configuration"
+                "envDesc": "Specify an environment configuration",
+                "disableStateDesc": "Does not use the saved state.json file. State is computed for each execution.",
+                "logPluginCallsDesc": "Logs any execution calls to a plugin to the console",
+                "npmInitRequired": "This project isn't a valid NPM project. Please run: npm init"
             }
         }
     }

--- a/taqueria-config.ts
+++ b/taqueria-config.ts
@@ -61,13 +61,14 @@ export const defaultConfig : Config = {
 
 export const getDefaultMaxConcurrency = () => 10
 
-export const make = (data: object) : Future<TaqError, Config> => {
+export const make = (data: Record<string, unknown>) : Future<TaqError, ConfigArgs> => {
     // TODO: Change decoding/validation library
     const err = undefined
     const validData = {
         ...defaultConfig,
         ...data
     }
+
     // const [err, validData] = validate(data, ConfigDecoder)
     return err === undefined
         ? resolve(validData)
@@ -100,8 +101,9 @@ export const getRawConfig = (projectDir: SanitizedAbsPath, configDir: SanitizedP
             SHA256.futureOf(JSON.stringify(config)),
             map ((hash: string) => ({
                 ...config,
-                configFile: path,
-                configDir, projectDir,
+                configFile: SanitizedAbsPath.create(path),
+                configDir,
+                projectDir,
                 hash
             }))
         )),

--- a/taqueria-plugin-flextesa/docker/package-lock.json
+++ b/taqueria-plugin-flextesa/docker/package-lock.json
@@ -1,0 +1,460 @@
+{
+  "name": "@taqueria/flextesa-docker",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@taqueria/flextesa-docker",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "partial.lenses": "^14.17.0",
+        "promise-retry": "^2.0.1",
+        "yargs": "^17.3.1"
+      },
+      "devDependencies": {
+        "esbuild": "^0.14.11",
+        "typescript": "^4.5.4"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+    },
+    "node_modules/esbuild": {
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.11.tgz",
+      "integrity": "sha512-xZvPtVj6yecnDeFb3KjjCM6i7B5TCAQZT77kkW/CpXTMnd6VLnRPKrUB1XHI1pSq6a4Zcy3BGueQ8VljqjDGCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.14.11",
+        "esbuild-darwin-64": "0.14.11",
+        "esbuild-darwin-arm64": "0.14.11",
+        "esbuild-freebsd-64": "0.14.11",
+        "esbuild-freebsd-arm64": "0.14.11",
+        "esbuild-linux-32": "0.14.11",
+        "esbuild-linux-64": "0.14.11",
+        "esbuild-linux-arm": "0.14.11",
+        "esbuild-linux-arm64": "0.14.11",
+        "esbuild-linux-mips64le": "0.14.11",
+        "esbuild-linux-ppc64le": "0.14.11",
+        "esbuild-linux-s390x": "0.14.11",
+        "esbuild-netbsd-64": "0.14.11",
+        "esbuild-openbsd-64": "0.14.11",
+        "esbuild-sunos-64": "0.14.11",
+        "esbuild-windows-32": "0.14.11",
+        "esbuild-windows-64": "0.14.11",
+        "esbuild-windows-arm64": "0.14.11"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.11.tgz",
+      "integrity": "sha512-olq84ikh6TiBcrs3FnM4eR5VPPlcJcdW8BnUz/lNoEWYifYQ+Po5DuYV1oz1CTFMw4k6bQIZl8T3yxL+ZT2uvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/infestines": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/infestines/-/infestines-0.4.11.tgz",
+      "integrity": "sha512-09nHagZLOYUaXKHqdV+nxEaYaD0hRlKyhQMhgTMwfbvWpMkowXf4XLZzAkLq6Y90wZ7Wqm6aMoL2trBsNNKGeg=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial.lenses": {
+      "version": "14.17.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses/-/partial.lenses-14.17.0.tgz",
+      "integrity": "sha512-Iq+wDw5b5iwmn7b9MO+//buOqF0YoAC2Hsj+HoeG88BGeT3NkL/YwHNGDrySyX7xZSqj0LFEWwfgGSj4cSFmXQ==",
+      "dependencies": {
+        "infestines": "^0.4.11"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+    },
+    "esbuild": {
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.11.tgz",
+      "integrity": "sha512-xZvPtVj6yecnDeFb3KjjCM6i7B5TCAQZT77kkW/CpXTMnd6VLnRPKrUB1XHI1pSq6a4Zcy3BGueQ8VljqjDGCg==",
+      "dev": true,
+      "requires": {
+        "esbuild-android-arm64": "0.14.11",
+        "esbuild-darwin-64": "0.14.11",
+        "esbuild-darwin-arm64": "0.14.11",
+        "esbuild-freebsd-64": "0.14.11",
+        "esbuild-freebsd-arm64": "0.14.11",
+        "esbuild-linux-32": "0.14.11",
+        "esbuild-linux-64": "0.14.11",
+        "esbuild-linux-arm": "0.14.11",
+        "esbuild-linux-arm64": "0.14.11",
+        "esbuild-linux-mips64le": "0.14.11",
+        "esbuild-linux-ppc64le": "0.14.11",
+        "esbuild-linux-s390x": "0.14.11",
+        "esbuild-netbsd-64": "0.14.11",
+        "esbuild-openbsd-64": "0.14.11",
+        "esbuild-sunos-64": "0.14.11",
+        "esbuild-windows-32": "0.14.11",
+        "esbuild-windows-64": "0.14.11",
+        "esbuild-windows-arm64": "0.14.11"
+      }
+    },
+    "esbuild-darwin-64": {
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.11.tgz",
+      "integrity": "sha512-olq84ikh6TiBcrs3FnM4eR5VPPlcJcdW8BnUz/lNoEWYifYQ+Po5DuYV1oz1CTFMw4k6bQIZl8T3yxL+ZT2uvQ==",
+      "dev": true,
+      "optional": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "infestines": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/infestines/-/infestines-0.4.11.tgz",
+      "integrity": "sha512-09nHagZLOYUaXKHqdV+nxEaYaD0hRlKyhQMhgTMwfbvWpMkowXf4XLZzAkLq6Y90wZ7Wqm6aMoL2trBsNNKGeg=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "partial.lenses": {
+      "version": "14.17.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses/-/partial.lenses-14.17.0.tgz",
+      "integrity": "sha512-Iq+wDw5b5iwmn7b9MO+//buOqF0YoAC2Hsj+HoeG88BGeT3NkL/YwHNGDrySyX7xZSqj0LFEWwfgGSj4cSFmXQ==",
+      "requires": {
+        "infestines": "^0.4.11"
+      }
+    },
+    "promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "requires": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yargs": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+    }
+  }
+}

--- a/taqueria-plugin-flextesa/index.ts
+++ b/taqueria-plugin-flextesa/index.ts
@@ -2,7 +2,7 @@ import {Plugin, Task, PositionalArg} from '@taqueria/node-sdk'
 import proxy from './proxy'
 
 Plugin.create(_i18n => ({
-    name: "flextesa",
+    alias: "flextesa",
     schema: "1.0",
     version: "0.1",
     tasks: [

--- a/taqueria-plugin-flextesa/package-lock.json
+++ b/taqueria-plugin-flextesa/package-lock.json
@@ -24,13 +24,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@taqueria/protocol": "file:../taqueria-protocol",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "yargs": "^17.2.1"
       },
       "devDependencies": {
         "@bevry/jsonfile": "^1.3.0",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "caller-id": "^0.1.0",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
         "typescript": "^4.5.2"
       }
@@ -8368,9 +8374,15 @@
         "@bevry/jsonfile": "^1.3.0",
         "@taqueria/protocol": "file:../taqueria-protocol",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "caller-id": "^0.1.0",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",
         "yargs": "^17.2.1"
       }

--- a/taqueria-plugin-ligo/compile.js
+++ b/taqueria-plugin-ligo/compile.js
@@ -23,26 +23,6 @@ const getCompileCommand = (opts, arch) => (sourceFile) => {
     return cmd
 }
 
-const execCmd = cmd => new Promise((resolve, reject) => {
-    exec(cmd, (err, stdout, stderr) => {
-        if (err) reject({
-            status: 'failed',
-            stdout: "",
-            stderr: err
-        })
-        else if (stderr) reject({
-            status: 'failed',
-            stdout,
-            stderr
-        })
-        else resolve({
-            status: 'success',
-            stdout,
-            stderr
-        })
-    })
-})
-
 const compileContract = (opts) => (sourceFile) =>
     getArch()
     .then(arch => getCompileCommand(opts, arch) (sourceFile))

--- a/taqueria-plugin-ligo/compile.js
+++ b/taqueria-plugin-ligo/compile.js
@@ -1,4 +1,4 @@
-import {execCmd, getArch} from '@taqueria/node-sdk'
+const {execCmd, getArch} = require('@taqueria/node-sdk')
 const {extname, basename, join} = require('path')
 const glob = require('fast-glob')
 

--- a/taqueria-plugin-ligo/compile.js
+++ b/taqueria-plugin-ligo/compile.js
@@ -1,6 +1,7 @@
-const {exec} = require('child_process')
+import {execCmd, getArch} from '@taqueria/node-sdk'
 const {extname, basename, join} = require('path')
 const glob = require('fast-glob')
+
 
 const getContractArtifactFilename = (opts) => (sourceFile) => {
     const outFile = basename(sourceFile, extname(sourceFile))
@@ -11,10 +12,10 @@ const getInputFilename = (opts) => sourceFile => {
     return join(opts.config.contractsDir, sourceFile)
 }
 
-const getCompileCommand = (opts) => (sourceFile) => {
+const getCompileCommand = (opts, arch) => (sourceFile) => {
     const {projectDir} = opts
     const inputFile = getInputFilename (opts) (sourceFile)
-    const baseCommand = `docker run --rm -v \"${projectDir}\":/project -w /project ligolang/ligo:next compile contract ${inputFile}`
+    const baseCommand = `docker run --platform ${arch} --rm -v \"${projectDir}\":/project -w /project ligolang/ligo:next compile contract ${inputFile}`
     const entryPoint = opts.e ? `-e ${opts.e}` : ""
     const syntax = opts["-s"] ? `s ${opts['s']} : ""` : ""
     const outFile = `-o ${getContractArtifactFilename(opts)(sourceFile)}`
@@ -43,7 +44,9 @@ const execCmd = cmd => new Promise((resolve, reject) => {
 })
 
 const compileContract = (opts) => (sourceFile) =>
-    execCmd(getCompileCommand(opts) (sourceFile))
+    getArch()
+    .then(arch => getCompileCommand(opts, arch) (sourceFile))
+    .then(execCmd)
     .then(() => ({contract: sourceFile, artifact: getContractArtifactFilename(opts) (sourceFile)}))
 
 const compileAll = parsedArgs => {

--- a/taqueria-plugin-ligo/index.js
+++ b/taqueria-plugin-ligo/index.js
@@ -4,7 +4,7 @@ const compile = require('./compile')
 Plugin.create(i18n => ({
     schema: "1.0",
     version: "0.1",
-    name: "taqueria-plugin-ligo",
+    alias: "ligo",
     tasks: [
         Task.create({
             task: "compile",

--- a/taqueria-plugin-ligo/package-lock.json
+++ b/taqueria-plugin-ligo/package-lock.json
@@ -39,13 +39,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@taqueria/protocol": "file:../taqueria-protocol",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "yargs": "^17.2.1"
       },
       "devDependencies": {
         "@bevry/jsonfile": "^1.3.0",
         "@types/json-schema-generator": "^2.0.0",
         "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
+        "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
         "typescript": "^4.5.2"
@@ -1059,9 +1064,14 @@
         "@taqueria/protocol": "file:../taqueria-protocol",
         "@types/json-schema-generator": "^2.0.0",
         "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
+        "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",
         "yargs": "^17.2.1"
       },

--- a/taqueria-plugin-ligo/package-lock.json
+++ b/taqueria-plugin-ligo/package-lock.json
@@ -44,8 +44,9 @@
       "devDependencies": {
         "@bevry/jsonfile": "^1.3.0",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
         "typescript": "^4.5.2"
       }
@@ -1057,8 +1058,9 @@
         "@bevry/jsonfile": "^1.3.0",
         "@taqueria/protocol": "file:../taqueria-protocol",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
         "typescript": "^4.5.2",
         "yargs": "^17.2.1"

--- a/taqueria-plugin-mock/package-lock.json
+++ b/taqueria-plugin-mock/package-lock.json
@@ -18,13 +18,19 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@taqueria/protocol": "file:../taqueria-protocol",
+                "project-name-generator": "^2.1.9",
+                "stack-trace": "^1.0.0-pre1",
                 "yargs": "^17.2.1"
             },
             "devDependencies": {
                 "@bevry/jsonfile": "^1.3.0",
                 "@types/json-schema-generator": "^2.0.0",
+                "@types/node": "^17.0.12",
+                "@types/project-name-generator": "^2.1.1",
+                "@types/stack-trace": "^0.0.29",
                 "@types/yargs": "^17.0.7",
-                "esbuild": "^0.14.7",
+                "caller-id": "^0.1.0",
+                "esbuild": "^0.14.13",
                 "json-schema-generator": "^2.0.6",
                 "typescript": "^4.5.2"
             }
@@ -41,9 +47,15 @@
                 "@bevry/jsonfile": "^1.3.0",
                 "@taqueria/protocol": "file:../taqueria-protocol",
                 "@types/json-schema-generator": "^2.0.0",
+                "@types/node": "^17.0.12",
+                "@types/project-name-generator": "^2.1.1",
+                "@types/stack-trace": "^0.0.29",
                 "@types/yargs": "^17.0.7",
-                "esbuild": "^0.14.7",
+                "caller-id": "^0.1.0",
+                "esbuild": "^0.14.13",
                 "json-schema-generator": "^2.0.6",
+                "project-name-generator": "^2.1.9",
+                "stack-trace": "^1.0.0-pre1",
                 "typescript": "^4.5.2",
                 "yargs": "^17.2.1"
             }

--- a/taqueria-plugin-smartpy/index.ts
+++ b/taqueria-plugin-smartpy/index.ts
@@ -2,7 +2,7 @@ import {Plugin, Task, Option} from '@taqueria/node-sdk'
 import compile from './compile'
 
 Plugin.create(i18n => ({
-    name: "smartpy",
+    alias: "smartpy",
     schema: "1.0",
     version: "0.1",
     tasks: [

--- a/taqueria-plugin-smartpy/package-lock.json
+++ b/taqueria-plugin-smartpy/package-lock.json
@@ -43,13 +43,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@taqueria/protocol": "file:../taqueria-protocol",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "yargs": "^17.2.1"
       },
       "devDependencies": {
         "@bevry/jsonfile": "^1.3.0",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "caller-id": "^0.1.0",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
         "typescript": "^4.5.2"
       }
@@ -9217,9 +9223,15 @@
         "@bevry/jsonfile": "^1.3.0",
         "@taqueria/protocol": "file:../taqueria-protocol",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "caller-id": "^0.1.0",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",
         "yargs": "^17.2.1"
       },

--- a/taqueria-plugin-taquito/index.ts
+++ b/taqueria-plugin-taquito/index.ts
@@ -3,7 +3,7 @@ import type { i18n} from '@taqueria/node-sdk/types'
 import originate from './originate'
 
 Plugin.create((i18n: i18n) => ({
-    name: "taquito",
+    alias: "taquito",
     schema: "1.0",
     version: "0.1",
     tasks: [

--- a/taqueria-plugin-taquito/package-lock.json
+++ b/taqueria-plugin-taquito/package-lock.json
@@ -45,13 +45,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@taqueria/protocol": "file:../taqueria-protocol",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "yargs": "^17.2.1"
       },
       "devDependencies": {
         "@bevry/jsonfile": "^1.3.0",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "caller-id": "^0.1.0",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
         "typescript": "^4.5.2"
       }
@@ -9511,9 +9517,15 @@
         "@bevry/jsonfile": "^1.3.0",
         "@taqueria/protocol": "file:../taqueria-protocol",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "caller-id": "^0.1.0",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",
         "yargs": "^17.2.1"
       },

--- a/taqueria-plugin-teztnets/package-lock.json
+++ b/taqueria-plugin-teztnets/package-lock.json
@@ -44,13 +44,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@taqueria/protocol": "file:../taqueria-protocol",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "yargs": "^17.2.1"
       },
       "devDependencies": {
         "@bevry/jsonfile": "^1.3.0",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "caller-id": "^0.1.0",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
         "typescript": "^4.5.2"
       }
@@ -1162,9 +1168,15 @@
         "@bevry/jsonfile": "^1.3.0",
         "@taqueria/protocol": "file:../taqueria-protocol",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
-        "esbuild": "^0.14.7",
+        "caller-id": "^0.1.0",
+        "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",
         "yargs": "^17.2.1"
       },

--- a/taqueria-protocol/taqueria-protocol-types.ts
+++ b/taqueria-protocol/taqueria-protocol-types.ts
@@ -222,6 +222,7 @@ export interface UnvalidatedTask {
 export interface UnvalidatedPluginInfo {
     readonly schema: string
     readonly name: string
+    readonly alias?: string
     readonly version: string
     readonly tasks?: (UnvalidatedTask|undefined)[]
     readonly scaffolds?: (UnvalidatedScaffold|undefined)[]
@@ -233,14 +234,16 @@ export interface UnvalidatedPluginInfo {
 export class PluginInfo {
     readonly schema: string
     readonly name: string
+    readonly alias?: string
     readonly version: string
     readonly tasks: Task[]
     readonly scaffolds: Scaffold[]
     readonly hooks: Hook[]
     readonly networks: Network[]
     readonly sandboxes: Sandbox[]
-    constructor(schema: string, name: string, version: string, tasks: Task[], scaffolds: Scaffold[], hooks: Hook[], networks: Network[], sandboxes: Sandbox[]) {
+    constructor(schema: string, name: string, version: string, tasks: Task[], scaffolds: Scaffold[], hooks: Hook[], networks: Network[], sandboxes: Sandbox[], alias?: string) {
         this.schema = schema
+        this.alias = alias
         this.name = name
         this.version = version
         this.tasks = tasks
@@ -274,7 +277,12 @@ export class PluginInfo {
                 const createTask = Task.create.bind(Task)
                 //TODO: Finish doing the above for each factory/constructor
 
+                const temp: Record<string, string> = obj.alias
+                    ? {alias: obj.alias}
+                    : {}
+
                 const pluginInfo : PluginInfo = {
+                    ...temp,
                     name: obj.name,
                     schema: obj.schema,
                     version: obj.version,

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -97,14 +97,19 @@ const viewTask = ({task, command, aliases, description, options, positionals, ha
     handler: handler === "proxy" ? "proxy" : handler
 })
 
+const resolvePluginName = (givenName?: string): string =>
+    givenName && givenName.length > 2
+        ? givenName
+        : require('./package.json').name
 
 
 const parseSchema = (i18n: i18n, definer: pluginDefiner): SchemaView | undefined => {
     try {
-        const {name, schema, version, tasks, scaffolds, hooks, networks, sandboxes, ...functions} = definer(i18n)
+        const {name, alias, schema, version, tasks, scaffolds, hooks, networks, sandboxes, ...functions} = definer(i18n)
 
         return {
-            name,
+            name: resolvePluginName(name),
+            alias,
             schema,
             version,
             tasks: tasks

--- a/taqueria-sdk/package-lock.json
+++ b/taqueria-sdk/package-lock.json
@@ -10,13 +10,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@taqueria/protocol": "file:../taqueria-protocol",
+        "project-name-generator": "^2.1.9",
+        "stack-trace": "^1.0.0-pre1",
         "yargs": "^17.2.1"
       },
       "devDependencies": {
         "@bevry/jsonfile": "^1.3.0",
         "@types/json-schema-generator": "^2.0.0",
         "@types/node": "^17.0.12",
+        "@types/project-name-generator": "^2.1.1",
+        "@types/stack-trace": "^0.0.29",
         "@types/yargs": "^17.0.7",
+        "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
         "typescript": "^4.5.2"
@@ -79,6 +84,18 @@
       "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
       "dev": true
     },
+    "node_modules/@types/project-name-generator": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/project-name-generator/-/project-name-generator-2.1.1.tgz",
+      "integrity": "sha512-VLd5FEVTJs8hNa/WF4pZRcFvv0OAcIGeTyki4RDcaID0TUhTc5/Xe/btYM2XIHwVCb67ila8wUJYKJNa5dVABw==",
+      "dev": true
+    },
+    "node_modules/@types/stack-trace": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.7",
       "dev": true,
@@ -112,6 +129,27 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/caller-id": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
+      "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
+      "dev": true,
+      "dependencies": {
+        "stack-trace": "~0.0.7"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/caller-id/node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "license": "ISC",
@@ -134,6 +172,14 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -975,11 +1021,36 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/project-name-generator": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/project-name-generator/-/project-name-generator-2.1.9.tgz",
+      "integrity": "sha512-QmLHqz2C4VHmAyDEAFlVfnuWAHr4vwZhK2bbm4IrwuHNzNKOdG9b4U+NmQbsm1uOoV4kGWv7+FVLsu7Bb/ieYQ==",
+      "dependencies": {
+        "commander": "^6.1.0",
+        "lodash": "^4.17.20"
+      },
+      "bin": {
+        "project-name-generator": "src/generator-bin.js"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "1.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0-pre1.tgz",
+      "integrity": "sha512-biM7OwS3J2hcou7tfozHcsqhJZxX5pqMMqe/Zr6stw9uVn8Gh7ct3eFR9Gb66BBi/ToSeOgk4FsjKgZVrDIyew==",
+      "engines": {
+        "node": "16"
       }
     },
     "node_modules/string-width": {
@@ -1099,6 +1170,18 @@
       "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
       "dev": true
     },
+    "@types/project-name-generator": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/project-name-generator/-/project-name-generator-2.1.1.tgz",
+      "integrity": "sha512-VLd5FEVTJs8hNa/WF4pZRcFvv0OAcIGeTyki4RDcaID0TUhTc5/Xe/btYM2XIHwVCb67ila8wUJYKJNa5dVABw==",
+      "dev": true
+    },
+    "@types/stack-trace": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "17.0.7",
       "dev": true,
@@ -1119,6 +1202,23 @@
         "color-convert": "^2.0.1"
       }
     },
+    "caller-id": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
+      "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
+      "dev": true,
+      "requires": {
+        "stack-trace": "~0.0.7"
+      },
+      "dependencies": {
+        "stack-trace": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+          "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+          "dev": true
+        }
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "requires": {
@@ -1135,6 +1235,11 @@
     },
     "color-name": {
       "version": "1.1.4"
+    },
+    "commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "emoji-regex": {
       "version": "8.0.0"
@@ -1685,8 +1790,27 @@
         }
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "project-name-generator": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/project-name-generator/-/project-name-generator-2.1.9.tgz",
+      "integrity": "sha512-QmLHqz2C4VHmAyDEAFlVfnuWAHr4vwZhK2bbm4IrwuHNzNKOdG9b4U+NmQbsm1uOoV4kGWv7+FVLsu7Bb/ieYQ==",
+      "requires": {
+        "commander": "^6.1.0",
+        "lodash": "^4.17.20"
+      }
+    },
     "require-directory": {
       "version": "2.1.1"
+    },
+    "stack-trace": {
+      "version": "1.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0-pre1.tgz",
+      "integrity": "sha512-biM7OwS3J2hcou7tfozHcsqhJZxX5pqMMqe/Zr6stw9uVn8Gh7ct3eFR9Gb66BBi/ToSeOgk4FsjKgZVrDIyew=="
     },
     "string-width": {
       "version": "4.2.3",

--- a/taqueria-sdk/package-lock.json
+++ b/taqueria-sdk/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@bevry/jsonfile": "^1.3.0",
         "@types/json-schema-generator": "^2.0.0",
+        "@types/node": "^17.0.12",
         "@types/yargs": "^17.0.7",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
@@ -71,6 +72,12 @@
       "dependencies": {
         "@types/json-schema": "*"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
+      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.7",
@@ -1085,6 +1092,12 @@
       "requires": {
         "@types/json-schema": "*"
       }
+    },
+    "@types/node": {
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
+      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.7",

--- a/taqueria-sdk/package.json
+++ b/taqueria-sdk/package.json
@@ -38,13 +38,18 @@
   "homepage": "https://github.com/ecadlabs/taqueria#readme",
   "dependencies": {
     "@taqueria/protocol": "file:../taqueria-protocol",
+    "project-name-generator": "^2.1.9",
+    "stack-trace": "^1.0.0-pre1",
     "yargs": "^17.2.1"
   },
   "devDependencies": {
     "@bevry/jsonfile": "^1.3.0",
     "@types/json-schema-generator": "^2.0.0",
     "@types/node": "^17.0.12",
+    "@types/project-name-generator": "^2.1.1",
+    "@types/stack-trace": "^0.0.29",
     "@types/yargs": "^17.0.7",
+    "caller-id": "^0.1.0",
     "esbuild": "^0.14.13",
     "json-schema-generator": "^2.0.6",
     "typescript": "^4.5.2"

--- a/taqueria-sdk/package.json
+++ b/taqueria-sdk/package.json
@@ -16,7 +16,6 @@
     "prod-config": "npm run backup-config && npm run set-protocol-version && npm run set-protocol-version-lock",
     "build-prod": "npm run backup-config && npm run prod-config && npm run build && npm run restore-config"
   },
-
   "keywords": [
     "taqueria",
     "tezos",
@@ -28,13 +27,11 @@
   ],
   "author": "ECAD Labs",
   "license": "Apache-2.0",
-
   "repository": {
     "type": "git",
     "url": "https://github.com/ecadlabs/taqueria.git",
     "directory": "taqueria-sdk"
   },
-
   "bugs": {
     "url": "https://github.com/ecadlabs/taqueria/issues"
   },
@@ -46,6 +43,7 @@
   "devDependencies": {
     "@bevry/jsonfile": "^1.3.0",
     "@types/json-schema-generator": "^2.0.0",
+    "@types/node": "^17.0.12",
     "@types/yargs": "^17.0.7",
     "esbuild": "^0.14.13",
     "json-schema-generator": "^2.0.6",

--- a/taqueria-sdk/types.ts
+++ b/taqueria-sdk/types.ts
@@ -1,4 +1,4 @@
-import {TaskHandler, Action, Scaffold, Hook, Sandbox as theSandbox, Network, Attributes as theAttributes, RuntimeDependency, Task, UnvalidatedSandbox, UnvalidatedHook, UnvalidatedOption, UnvalidatedScaffold, UnvalidatedNetwork, EconomicalProtocol as theProtocol, UnvalidatedPositionalArg, OptionType, Environment as anEnvironment, SandboxConfig as theSandboxConfig, NetworkConfig as theNetworkConfig, EnvironmentConfig} from 'taqueria-protocol/taqueria-protocol-types'
+import {Action, Scaffold, Hook, Sandbox as theSandbox, Network, Attributes as theAttributes, RuntimeDependency, Task, UnvalidatedSandbox, UnvalidatedHook, UnvalidatedOption, UnvalidatedScaffold, UnvalidatedNetwork, EconomicalProtocol as theProtocol, UnvalidatedPositionalArg, OptionType, Environment as anEnvironment, SandboxConfig as theSandboxConfig, NetworkConfig as theNetworkConfig, EnvironmentConfig} from '@taqueria/protocol/taqueria-protocol-types'
 
 export type Sandbox = theSandbox
 
@@ -79,9 +79,16 @@ export interface ActionPluginInfo extends SchemaView {
 
 export type ActionResponse = ProxyAction | CheckRuntimeDependenciesAction | InstallRuntimeDependenciesAction | ActionPluginInfo | ActionNotSupported
 
+/**
+ * A Schema for a plugin should have the same properties as the PluginInfo type, but
+ * many of the properties are optional rather than required as in the PluginInfo type:
+ * - name (optional, as this can be inferred from the package.json file)
+ * - tasks, scaffolds, hooks, networks, and sandboxes - a plugin can provide 0 or more of these constructs
+ */
 export interface Schema {
     // This should match the PluginInfo, but tasks, scaffolds, hooks, networks, and sandboxes are optional
-    readonly name: string
+    readonly name?: string
+    readonly alias?: string
     readonly schema: string
     readonly version: string
     readonly tasks?: (Task | undefined)[]
@@ -96,6 +103,7 @@ export interface Schema {
 
 export interface SchemaView {
     readonly name: string
+    readonly alias?: string
     readonly schema: string
     readonly version: string
     readonly tasks: TaskView[]

--- a/taqueria-types.ts
+++ b/taqueria-types.ts
@@ -46,6 +46,9 @@ export interface RawInitArgs {
     plugin?: string
     env: 'production' | 'development' | 'testing' | string
     quickstart: string
+    disableState: boolean
+    logPluginCalls: boolean
+    build: string
 }
 
 export interface SanitizedInitArgs {
@@ -57,13 +60,16 @@ export interface SanitizedInitArgs {
     plugin?: string
     env: 'production' | 'development' | 'testing' | string
     quickstart: string
+    disableState: boolean
+    logPluginCalls: boolean
+    build: string
 }
 
 export interface i18n {
     __(msg: string, ...params: string[]): string
 }
 
-export type EnvKey = "TAQ_CONFIG_DIR" | "TAQ_MAX_CONCURRENCY" | "TAQ_PROJECT_DIR" | "TAQ_ENV"
+export type EnvKey = "TAQ_CONFIG_DIR" | "TAQ_MAX_CONCURRENCY" | "TAQ_PROJECT_DIR" | "TAQ_ENV" | "TAQ_DISABLE_STATE"
 
 export interface EnvVars {
     get: (key: EnvKey) => undefined | string
@@ -119,16 +125,18 @@ type TaskCounts = Record<string, string[]>
 
 export class State {
     [stateType]: void
+    build: string
     configHash: SHA256
     tasks: PluginTaskMap
     networks: Network[]
     plugins: PluginInfo[]
 
-    protected constructor(configHash: SHA256, tasks: PluginTaskMap, networks: Network[], plugins: PluginInfo[]) {
+    protected constructor(build: string, configHash: SHA256, tasks: PluginTaskMap, networks: Network[], plugins: PluginInfo[]) {
         this.configHash = configHash
         this.tasks = tasks
         this.networks = networks
         this.plugins = plugins
+        this.build = build
     }
 
     protected static mapTasksToPlugins = (config: Config, pluginInfo: PluginInfo[], i18n: i18n) => {
@@ -204,8 +212,8 @@ export class State {
         []
     )
 
-    static create(config: ConfigArgs, pluginInfo: PluginInfo[], i18n: i18n) {
+    static create(build: string, config: ConfigArgs, pluginInfo: PluginInfo[], i18n: i18n) {
         const taskMap = this.mapTasksToPlugins(config, pluginInfo, i18n)
-        return new State(config.hash, taskMap, [], pluginInfo)
+        return new State(build, config.hash, taskMap, [], pluginInfo)
     }
 }

--- a/taqueria-utils/taqueria-utils-types.ts
+++ b/taqueria-utils/taqueria-utils-types.ts
@@ -36,17 +36,20 @@ export class SanitizedPath extends StringLike{
 }
 
 const sanitizedAbsPath: unique symbol = Symbol()
-export class SanitizedAbsPath extends SanitizedPath {
+export class SanitizedAbsPath {
     [sanitizedAbsPath]: void
-    protected constructor(value: string) {
-        super(resolvePath(value))
+    readonly value: string
+    protected constructor(value: string, cwd?: SanitizedAbsPath) {
+        this.value = cwd
+            ? resolvePath(cwd.join(value).value)
+            : resolvePath(value)
     }
     public join(...paths: string[]): SanitizedAbsPath {
         return new SanitizedAbsPath(join(this.value, ...paths))
     }
     
-    static create(value: string) {
-        return new SanitizedAbsPath(super.create(value).value)
+    static create(value: string, cwd?: SanitizedAbsPath) {
+        return new SanitizedAbsPath(value, cwd)
     }
 }
 

--- a/taqueria-utils/taqueria-utils.ts
+++ b/taqueria-utils/taqueria-utils.ts
@@ -23,6 +23,12 @@ export const log = <T>(message: string) => (input: T) : T => {
     return input
 }
 
+
+export const debug = <T>(input: T) => {
+    debugger
+    return input
+}
+
 const mkdirFuture = (path: string): Future<TaqError, void> => attemptP(() => Deno.mkdir(path, {recursive: true}))
 
 export const mkdir = (path: string) : Future<TaqError, string> => pipe(path, mkdirFuture, map (() => path))


### PR DESCRIPTION
This branch fixes #147 but also makes a few other adjustments:
- Adds a task for installing and uninstalling an NPM plugin.  For installation, you can use `taq install @taqueria/plugin-ligo` once the packages are published to npmjs, but `taq install /path/to/taqueria-plugin-ligo` should also work. To uninstall, you must specify the package name - directory paths aren't supported.
- Error messages aren't truncated. This will help with debugging.
- Adds an argument flag for logging plugin requests. When debugging, I often have to uncomment a line in the source of taqueria and re-build. I can then see calls to a plugin logged to the console. I've asked others, like @russellmorton to do this. To make this a little easier, you can now just specify a hidden argument to the taq binary: `taq --logPluginCalls`
- When you execute a task using taqueria for the first time, we generate a .taq/state.json file which makes taqueria fast and performant. However, when debugging, you often have to delete this file in-between executions. To make this easier, you can now specifiy a hidden argument: `taq --disableState` which will generate a new state file for every execution. This makes taqueria slower, but should only be used for debugging anyhow.
- Its possible that we make changes to the schema used in state.json in later versions. Indeed, there's a slight schema change in this branch. The state.json file now includes a "build" property in the schema, which tracks the version of taqueria that generated the state.json file. Taqueria will now detect if the version of taqueria that you're using differs from the one that generated the state.json file, and regenerates it to assure that its using the most up-to-date schema
- One of the things we want to be able to do is have taqueria report what build (branch, commit, etc) was used to generate the binary. Although I haven't added that, I did add a mechanism that can be used to provide that information to taqueria. The next step is now just displaying/reporting that.
- In a call with Russel, we found that you cannot run `npm install [pluginName]` on a taqified directory if the directory isn't configured as an NPM project. This is done using the `npm init` command. Taqueria will now identify if this is an NPM project, and prompt you to run `npm init` if you try installing a plugin before the directory has been initialized as an NPM project

I think that's it. Although the above may look insignificant, there were changes required in a few different places to accommodate everything, so testing this branch before merging into main would be highly desirable.