### PR TITLE
refactor(ci): remove git tag from binary names for release assets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,9 +221,9 @@ jobs:
         id: download-binaries 
         run: |
           mkdir release && cd release
-          wget ${{ needs.build-binaries.outputs.public-url-ubuntu }} -O taq.${GITHUB_REF/refs\/tags\//}-linux
-          wget ${{ needs.build-binaries.outputs.public-url-windows }} -O taq.${GITHUB_REF/refs\/tags\//}-windows.exe
-          wget ${{ needs.build-binaries.outputs.public-url-macos }} -O taq.${GITHUB_REF/refs\/tags\//}-macos
+          wget ${{ needs.build-binaries.outputs.public-url-ubuntu }} -O taq-linux
+          wget ${{ needs.build-binaries.outputs.public-url-windows }} -O taq-windows.exe
+          wget ${{ needs.build-binaries.outputs.public-url-macos }} -O taq-macos
 
       - name: Release
         id: release


### PR DESCRIPTION
When we publish a release in GitHub the release tag is automatically added to the URL and we do not need this in the binary names. To make downloading the latest binaries easier we are removing the GitHub tag from the asset names.