### PR TITLE
fix(ci): assign exec permission to binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,6 +224,7 @@ jobs:
           wget ${{ needs.build-binaries.outputs.public-url-ubuntu }} -O taq.${GITHUB_REF/refs\/tags\//}-linux
           wget ${{ needs.build-binaries.outputs.public-url-windows }} -O taq.${GITHUB_REF/refs\/tags\//}-windows.exe
           wget ${{ needs.build-binaries.outputs.public-url-macos }} -O taq.${GITHUB_REF/refs\/tags\//}-macos
+          chmod +x *
 
       - name: Release
         id: release


### PR DESCRIPTION
## Summary

Currently after downloading a binary from Github we need to set exec permission ouself with `chmod +x`. Ideally we should let the pipeline do this for us.