### PR TITLE
fix(website): add redirects file for binary downloads

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && cp redirects.txt build/_redirects",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/website/redirects.txt
+++ b/website/redirects.txt
@@ -1,0 +1,3 @@
+/get/macos/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-macos 301
+/get/linux/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-linux 301
+/get/windows/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-windows.exe 301

--- a/website/redirects.txt
+++ b/website/redirects.txt
@@ -1,3 +1,3 @@
-/get/macos/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-macos 301
-/get/linux/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-linux 301
-/get/windows/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-windows.exe 301
+/get/macos/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-macos 307
+/get/linux/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-linux 307
+/get/windows/taq https://github.com/ecadlabs/taqueria/releases/latest/download/taq-windows.exe 307


### PR DESCRIPTION
This PR adds redirects for the Cloudflare pages site. The redirects will make downloading binaries simpler using friendly URLs.

**Testing Plan**
Please test by downloading the binaries from the following URLs

https://154-chore-redirects-for-webs.taqueria.pages.dev/get/macos/taq
https://154-chore-redirects-for-webs.taqueria.pages.dev/get/linux/taq
https://154-chore-redirects-for-webs.taqueria.pages.dev/get/windows/taq

Once this PR is merged the URLs will work for https://taqueria.io/

Ref #154 