### PR TITLE
ci: use `yarn` to package VSCode extension

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           pat: stub
           dryRun: true
+          yarn: true
           packagePath: ${{ env.VSCODE_DIR }}
       - id: setArtifactFilename
         run: echo "::set-output name=filename::taqueria-vscode-${{ github.head_ref || github.ref_name }}-${{ runner.os }}"


### PR DESCRIPTION
@mweichert reported an error when runnig the VS Code extension packaging pipeline.

https://github.com/ecadlabs/taqueria/runs/4987084269?check_suite_focus=true

![Screenshot from 2022-01-28 15-17-18](https://user-images.githubusercontent.com/22307776/151634706-b4e15f74-0a94-4ee5-88ff-bef4c78dbb82.png)

```
Error: Command failed: npm list --production --parseable --depth=99999 --loglevel=error
npm ERR! code ELSPROBLEMS
npm ERR! missing: typescript@^4.5.4, required by taqueria-protocol@npm:@taqueria/protocol@0.0.1
```

`vsce` is unable to reference a linked dependency and throws an error. There is an open GH Issue for this problem https://github.com/microsoft/vscode-vsce/issues/203

---

Using `yarn` with `vsce` seems to solve the issue and the extension gets built successfully. I tested this change in this pipeline which completed successfully https://github.com/ecadlabs/taqueria/runs/4987473254?check_suite_focus=true 

![Screenshot from 2022-01-28 15-49-31](https://user-images.githubusercontent.com/22307776/151636646-dece3ee7-cf0e-4440-8b09-fa5735f2ce5a.png)
