### PR TITLE
Use flextesa-plugin-use-ghcr-image in flextesa plugin

### DIFF
--- a/taqueria-plugin-flextesa/docker/package.json
+++ b/taqueria-plugin-flextesa/docker/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prebuild-package": "npm install",
     "build-package": "npx esbuild --platform=node --bundle startFlextesa.ts --outdir=.",
-    "build-docker": "docker build . -t taqueria/flextesa",
+    "build-docker": "docker build . -t ghcr.io/ecadlabs/taqueria-flextesa:latest",
     "build": "npm run build-package && npm run build-docker"
   },
   "keywords": ["taqueria", "docker", "flextesa", "sandbox", "local", "ecad", "ecadlabs", "tezos"],

--- a/taqueria-plugin-flextesa/package-lock.json
+++ b/taqueria-plugin-flextesa/package-lock.json
@@ -38,6 +38,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "typescript": "^4.5.2"
       }
     },
@@ -8381,6 +8382,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "project-name-generator": "^2.1.9",
         "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",

--- a/taqueria-plugin-flextesa/package-lock.json
+++ b/taqueria-plugin-flextesa/package-lock.json
@@ -14,6 +14,7 @@
         "promise-retry": "^2.0.1"
       },
       "devDependencies": {
+        "@types/promise-retry": "^1.1.3",
         "parcel": "^2.0.1",
         "typescript": "^4.5.2"
       }
@@ -1689,6 +1690,21 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/promise-retry": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
+      "integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "dev": true
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -8406,6 +8422,21 @@
     },
     "@types/parse-json": {
       "version": "4.0.0",
+      "dev": true
+    },
+    "@types/promise-retry": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
+      "integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
+    "@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
     "abab": {

--- a/taqueria-plugin-flextesa/package.json
+++ b/taqueria-plugin-flextesa/package.json
@@ -38,19 +38,18 @@
   },
   "author": "ECAD Labs",
   "license": "Apache-2.0",
-
   "repository": {
     "type": "git",
     "url": "https://github.com/ecadlabs/taqueria.git",
     "directory": "taqueria-plugin-flextesa"
   },
-
   "dependencies": {
+    "@taqueria/node-sdk": "file:../taqueria-sdk",
     "fast-glob": "^3.2.7",
-    "promise-retry": "^2.0.1",
-    "@taqueria/node-sdk": "file:../taqueria-sdk"
+    "promise-retry": "^2.0.1"
   },
   "devDependencies": {
+    "@types/promise-retry": "^1.1.3",
     "parcel": "^2.0.1",
     "typescript": "^4.5.2"
   }

--- a/taqueria-plugin-flextesa/proxy.ts
+++ b/taqueria-plugin-flextesa/proxy.ts
@@ -18,7 +18,7 @@ const attributesToParams = (attributes: Attributes): Record<string, string> => [
     {}
 )
 
-const getDockerImage = () => 'taqueria/flextesa:latest'
+const getDockerImage = () => 'ghcr.io/ecadlabs/taqueria-flextesa:latest'
 
 const getStartCommand = (sandbox: Sandbox, image: string, config: Opts, arch: string): string => {
     const _envVars = Object.entries(attributesToParams(sandbox.attributes)).reduce(

--- a/taqueria-plugin-ligo/package-lock.json
+++ b/taqueria-plugin-ligo/package-lock.json
@@ -53,6 +53,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "typescript": "^4.5.2"
       }
     },
@@ -1070,6 +1071,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "project-name-generator": "^2.1.9",
         "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",

--- a/taqueria-plugin-mock/package-lock.json
+++ b/taqueria-plugin-mock/package-lock.json
@@ -32,6 +32,7 @@
                 "caller-id": "^0.1.0",
                 "esbuild": "^0.14.13",
                 "json-schema-generator": "^2.0.6",
+                "parcel": "^2.2.1",
                 "typescript": "^4.5.2"
             }
         },
@@ -54,6 +55,7 @@
                 "caller-id": "^0.1.0",
                 "esbuild": "^0.14.13",
                 "json-schema-generator": "^2.0.6",
+                "parcel": "^2.2.1",
                 "project-name-generator": "^2.1.9",
                 "stack-trace": "^1.0.0-pre1",
                 "typescript": "^4.5.2",

--- a/taqueria-plugin-smartpy/package-lock.json
+++ b/taqueria-plugin-smartpy/package-lock.json
@@ -57,6 +57,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "typescript": "^4.5.2"
       }
     },
@@ -9230,6 +9231,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "project-name-generator": "^2.1.9",
         "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",

--- a/taqueria-plugin-taquito/package-lock.json
+++ b/taqueria-plugin-taquito/package-lock.json
@@ -59,6 +59,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "typescript": "^4.5.2"
       }
     },
@@ -9524,6 +9525,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "project-name-generator": "^2.1.9",
         "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",

--- a/taqueria-plugin-teztnets/package-lock.json
+++ b/taqueria-plugin-teztnets/package-lock.json
@@ -58,6 +58,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "typescript": "^4.5.2"
       }
     },
@@ -1175,6 +1176,7 @@
         "caller-id": "^0.1.0",
         "esbuild": "^0.14.13",
         "json-schema-generator": "^2.0.6",
+        "parcel": "^2.2.1",
         "project-name-generator": "^2.1.9",
         "stack-trace": "^1.0.0-pre1",
         "typescript": "^4.5.2",

--- a/taqueria-protocol/taqueria-protocol-types.ts
+++ b/taqueria-protocol/taqueria-protocol-types.ts
@@ -187,9 +187,14 @@ export interface UnvalidatedNetwork {
     readonly attributes?: Attributes
 }
 
+// NOTE: This is a workaround as TypeScript doesn't support
+// recursive / cyclical types yet. :(
+type Accounts_Base = Record<string, AccountDetails>
+export type Accounts = Record<string, (keyof Accounts_Base)|AccountDetails>
+
 export interface UnvalidatedSandbox extends UnvalidatedNetwork {
     readonly plugin?: string
-    readonly accounts?: Record<string, AccountDetails>
+    readonly accounts?: Accounts 
 }
 
 const hookType: unique symbol = Symbol()
@@ -464,7 +469,7 @@ export interface SandboxConfig {
     readonly rpcUrl?: string
     readonly protocol?: string
     readonly attributes?: Attributes
-    readonly accounts: Record<string|'default', AccountDetails|string>
+    readonly accounts: Accounts
 }
 
 export interface NetworkConfig {
@@ -510,6 +515,7 @@ export class EconomicalProtocolHash extends StringLike {
 
 const economicProtocalType: unique symbol = Symbol()
 export class EconomicalProtocol {
+    [economicProtocalType]: void
     readonly hash: EconomicalProtocolHash
     readonly label: HumanReadableIdentifier | undefined
     constructor(hash: EconomicalProtocolHash, label: (HumanReadableIdentifier|undefined)=undefined) {
@@ -555,11 +561,11 @@ export class Network {
 
 const sandboxType: unique symbol = Symbol()
 export class Sandbox extends Network {
-    readonly accounts: Record<string, AccountDetails>
+    readonly accounts: Accounts
     [sandboxType]: void
     readonly plugin?: string
 
-    protected constructor(name: HumanReadableIdentifier, label: StringMax30, rpcUrl: Url, protocol: EconomicalProtocol, attributes: Attributes, plugin?: string, accounts?: Record<string, AccountDetails>) {
+    protected constructor(name: HumanReadableIdentifier, label: StringMax30, rpcUrl: Url, protocol: EconomicalProtocol, attributes: Attributes, plugin?: string, accounts?: Accounts) {
         super(name, label, rpcUrl, protocol, attributes)
         this.plugin = plugin
         this.accounts = accounts ? accounts: {}


### PR DESCRIPTION
Before CI/CD for the docker image, the plugin has a script to build the docker image using the name `taqueria/flextesa`. As such, within the plugin itself, that image was referenced as well.

Also fixed an issue with some static typing for protocol accounts defined in the taqueria-protocol package.