### PR TITLE
Fixes multiple issues with LIGO plugin

### DIFF
--- a/taqueria-plugin-ligo/compile.js
+++ b/taqueria-plugin-ligo/compile.js
@@ -2,7 +2,6 @@ const {execCmd, getArch} = require('@taqueria/node-sdk')
 const {extname, basename, join} = require('path')
 const glob = require('fast-glob')
 
-
 const getContractArtifactFilename = (opts) => (sourceFile) => {
     const outFile = basename(sourceFile, extname(sourceFile))
     return join(opts.config.artifactsDir, `${outFile}.tz`)
@@ -23,11 +22,21 @@ const getCompileCommand = (opts, arch) => (sourceFile) => {
     return cmd
 }
 
+const getLigoCompilationError = (stderr) => {
+    const err = stderr.split("\n").slice(1).join("\n")
+    return `There was a compilation error.\n$\n{err}`
+}
+
 const compileContract = (opts) => (sourceFile) =>
     getArch()
     .then(arch => getCompileCommand(opts, arch) (sourceFile))
     .then(execCmd)
-    .then(() => ({contract: sourceFile, artifact: getContractArtifactFilename(opts) (sourceFile)}))
+    .then(result => result.status === 'success'
+        ? ({contract: sourceFile, artifact: getContractArtifactFilename(opts) (sourceFile)})
+        : Promise.reject({
+            errCode: "E_COMPILE", context: result, errMsg: getLigoCompilationError(result.stderr)}
+        )
+    )
 
 const compileAll = parsedArgs => {
     // TODO: Fetch list of files from SDK
@@ -42,14 +51,20 @@ const compileAll = parsedArgs => {
 const compile = parsedArgs => {
     const p = parsedArgs.sourceFile
         ? compileContract(parsedArgs) (parsedArgs.sourceFile)
+            .then(result => [result])
         : compileAll(parsedArgs)
     
-    return p.then(results => ({
+    return p
+    .then(results => ({
         status: 'success',
         stdout: results,
         stderr: "",
         render: 'table'
     }))
+    .catch(err => err.errCode
+        ? Promise.resolve({status: 'failed', stdout: '', stderr: err.errMsg, previous: err})
+        : Promise.resolve({status: 'failed', stderr: err.getMessage(), stdout: '', previous: err})
+    )
 }
 
 module.exports = compile


### PR DESCRIPTION
If a contract failed to compile when executing `taq compile`, the errors were hidden and taqueria would indicate that the compilation was successful despite there being a failure. This  issue is fixed in this branch.

Additionally, when trying to compile a specific contract using `taq compile <sourceFile>`, an error would be thrown:
```
error: TypeError: data.reduce is not a function
    at renderTable (file://$deno$/bundle.js:20115:30)
    at file://$deno$/bundle.js:20105:21
    at call (file://$deno$/bundle.js:3275:12)
    at Transformation.MapTransformation$resolved (file://$deno$/bundle.js:3779:42)
    at Transformation.transformationHandler [as resolved] (file://$deno$/bundle.js:3736:25)
    at resolved (file://$deno$/bundle.js:3644:31)
    at EncaseP$res (file://$deno$/bundle.js:3829:13)
```

This is resolved in this PR as well.