### PR TITLE
refactor(ci): add next or latest tag depending on pre-release event

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,12 +30,6 @@ jobs:
         with: 
           registry-url: ${{ env.NPM_REGISTRY }}
           scope: "${{ env.SCOPE }}"
-          
-      - name: Check tag suffix
-        id: check-tag-suffix
-        if: startsWith(github.ref, 'refs/tags/v') && (contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-test'))
-        run: |
-          echo "::set-output name=npm-tag::next"
 
       - name: Install any dependencies
         run: npm ci
@@ -50,12 +44,12 @@ jobs:
           npm publish --workspace $GIT_WORKSPACE --tag "preview" --access public
       
       - name: Publish for prerelease
-        if:  ${{ github.event_name == 'release' && github.event.action == 'published' && steps.check-tag-suffix.outputs.npm-tag == 'next'}}
+        if:  ${{ github.event.release.prerelease && github.event.action == 'published' }}
         run: |
           npm --no-git-tag-version version "${GITHUB_REF/refs\/tags\/v}" --workspace $GIT_WORKSPACE
           npm publish --workspace=$GIT_WORKSPACE --tag 'next' --access public
       
       - name: Publish for official release
-        if: ${{ github.event_name == 'release' && github.event.action == 'published' && steps.check-tag-suffix.outputs.npm-tag != 'next'}}
+        if: ${{ !github.event.release.prerelease && github.event.action == 'published' }}
         run: |
           npm publish --workspace=$GIT_WORKSPACE --tag 'latest' --access public


### PR DESCRIPTION
Updates the workflow to publish to npmjs.com with the `next` or `latest` tag depending on whether the GitHub workflow event is a `prerelease` or not

**Test Plan**
![image](https://user-images.githubusercontent.com/29157965/151879038-3d7498e0-6fae-469a-bfbc-cbf7661c0508.png)

![image](https://user-images.githubusercontent.com/29157965/151879218-2e56702a-08e3-450d-a976-88e80c2f988d.png)

![image](https://user-images.githubusercontent.com/29157965/151879308-526abd7f-f60b-404c-bd50-2331a953b1ba.png)
