### PR TITLE
ci: Use local template reference for Github reusable workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
   publish-flextesa-plugin-to-npm:
     needs:
       - publish-sdk-to-npm
-    uses: ecadlabs/taqueria/.github/workflows/npm-publish.yml@main
+    uses: ./.github/workflows/npm-publish.yml
     with:
       dir: taqueria-plugin-flextesa
     secrets:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
           echo "::set-output name=${{ matrix.os_short }}::https://storage.googleapis.com/taqueria-artifacts/${{ steps.upload-file.outputs.uploaded }}"
 
   publish-protocol-to-npm:
-    uses: ecadlabs/taqueria/.github/workflows/npm-publish.yml@main
+    uses: ./.github/workflows/npm-publish.yml
     with:
       dir: taqueria-protocol
     secrets:
@@ -96,7 +96,7 @@ jobs:
 
   publish-sdk-to-npm:
     needs: publish-protocol-to-npm
-    uses: ecadlabs/taqueria/.github/workflows/npm-publish.yml@main
+    uses: ./.github/workflows/npm-publish.yml
     with:
       dir: taqueria-sdk
     secrets:
@@ -104,7 +104,7 @@ jobs:
 
   publish-ligo-plugin-to-npm:
     needs: publish-sdk-to-npm
-    uses: ecadlabs/taqueria/.github/workflows/npm-publish.yml@main
+    uses: ./.github/workflows/npm-publish.yml
     with:
       dir: taqueria-plugin-ligo
     secrets:
@@ -112,7 +112,7 @@ jobs:
   
   publish-smartpy-plugin-to-npm:
     needs: publish-sdk-to-npm
-    uses: ecadlabs/taqueria/.github/workflows/npm-publish.yml@main
+    uses: ./.github/workflows/npm-publish.yml
     with:
       dir: taqueria-plugin-smartpy
     secrets:
@@ -120,7 +120,7 @@ jobs:
 
   publish-taquito-plugin-to-npm:
     needs: publish-sdk-to-npm
-    uses: ecadlabs/taqueria/.github/workflows/npm-publish.yml@main
+    uses: ./.github/workflows/npm-publish.yml@main
     with:
       dir: taqueria-plugin-taquito
     secrets:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
 
   publish-taquito-plugin-to-npm:
     needs: publish-sdk-to-npm
-    uses: ./.github/workflows/npm-publish.yml@main
+    uses: ./.github/workflows/npm-publish.yml
     with:
       dir: taqueria-plugin-taquito
     secrets:


### PR DESCRIPTION
The Github reusable workflows introduced in #156 are tricky to work with when trying to update the template workflow. Currently we need to explicitly point to the branch we are working on in each reusable workflow instantiation. This is messy as we can easily forget to point the workflow back to `main` branch before merging a PR.

Github introduced [Reusable workflows can be referenced locally](https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/ ) on Jan 25th 2022 which should solve this issue most users are experiencing issues https://github.community/t/allow-reusable-workflows-to-be-located-at-arbitrary-locations-and-be-local/212745/5?u=danielelisi