### PR TITLE
Attempt to fix vscode packaging

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -63,7 +63,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Copy node_modules folder on UNIX
-        run: cp -r ../node_modules .
+        run: cp -RL node_modules taqueria-vscode-extension/node_modules
         if: runner.os != 'Windows'
 
       - name: Copy node_modules folder on Windows

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -65,10 +65,6 @@ jobs:
       - name: Copy node_modules folder on UNIX
         run: rsync -av node_modules taqueria-vscode-extension/
         if: runner.os != 'Windows'
-
-      - name: Copy node_modules folder on Windows
-        run: xcopy node_modules taqueria-vscode-extension\node_modules /s /e
-        if: runner.os == 'Windows'
       
       - name: Package VSCode Extension
         if: runner.os == 'Linux'

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -63,7 +63,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Copy node_modules folder on UNIX
-        run: cp -RL node_modules taqueria-vscode-extension/node_modules
+        run: cp -RL node_modules taqueria-vscode-extension/
         if: runner.os != 'Windows'
 
       - name: Copy node_modules folder on Windows

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -67,7 +67,7 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Copy node_modules folder on Windows
-        run: xcopy ..\node_modules node_modules /s /e
+        run: xcopy node_modules taqueria-vscode-extension/node_modules /s /e
         if: runner.os == 'Windows'
       
       - name: Package VSCode Extension

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -54,14 +54,14 @@ jobs:
       - name: Compile TS
         run: npm run compile --workspace ${{ env.GIT_WORKSPACE }}
       
-      - name: Run Unit Tests on Windows or macOS
-        run: npm test --workspace ${{ env.GIT_WORKSPACE }}
-        if: runner.os != 'Linux'
+      # - name: Run Unit Tests on Windows or macOS
+      #   run: npm test --workspace ${{ env.GIT_WORKSPACE }}
+      #   if: runner.os != 'Linux'
       
-      - name: Run Unit Tests on Linux
-        run: xvfb-run -a npm test --workspace ${{ env.GIT_WORKSPACE }}
-        if: runner.os == 'Linux'
-              
+      # - name: Run Unit Tests on Linux
+      #   run: xvfb-run -a npm test --workspace ${{ env.GIT_WORKSPACE }}
+      #   if: runner.os == 'Linux'
+
       - name: Package VSCode Extension
         if: runner.os == 'Linux'
         id: packageExtension

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -54,13 +54,13 @@ jobs:
       - name: Compile TS
         run: npm run compile --workspace ${{ env.GIT_WORKSPACE }}
       
-      # - name: Run Unit Tests on Windows or macOS
-      #   run: npm test --workspace ${{ env.GIT_WORKSPACE }}
-      #   if: runner.os != 'Linux'
+      - name: Run Unit Tests on Windows or macOS
+        run: npm test --workspace ${{ env.GIT_WORKSPACE }}
+        if: runner.os != 'Linux'
       
-      # - name: Run Unit Tests on Linux
-      #   run: xvfb-run -a npm test --workspace ${{ env.GIT_WORKSPACE }}
-      #   if: runner.os == 'Linux'
+      - name: Run Unit Tests on Linux
+        run: xvfb-run -a npm test --workspace ${{ env.GIT_WORKSPACE }}
+        if: runner.os == 'Linux'
 
       - name: Package VSCode Extension
         if: runner.os == 'Linux'

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -61,6 +61,14 @@ jobs:
       - name: Run Unit Tests on Linux
         run: xvfb-run -a npm test --workspace ${{ env.GIT_WORKSPACE }}
         if: runner.os == 'Linux'
+
+      - name: Copy node_modules folder on UNIX
+        run: cp -r ../node_modules .
+        if: runner.os != 'Windows'
+
+      - name: Copy node_modules folder on Windows
+        run: xcopy ..\node_modules node_modules /s /e
+        if: runner.os == 'Windows'
       
       - name: Package VSCode Extension
         if: runner.os == 'Linux'

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -63,7 +63,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Copy node_modules folder on UNIX
-        run: cp -RL node_modules taqueria-vscode-extension/
+        run: rsync -av node_modules taqueria-vscode-extension/
         if: runner.os != 'Windows'
 
       - name: Copy node_modules folder on Windows

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -61,11 +61,7 @@ jobs:
       - name: Run Unit Tests on Linux
         run: xvfb-run -a npm test --workspace ${{ env.GIT_WORKSPACE }}
         if: runner.os == 'Linux'
-
-      - name: Copy node_modules folder on UNIX
-        run: rsync -av node_modules taqueria-vscode-extension/
-        if: runner.os != 'Windows'
-      
+              
       - name: Package VSCode Extension
         if: runner.os == 'Linux'
         id: packageExtension

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -67,7 +67,7 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Copy node_modules folder on Windows
-        run: xcopy node_modules taqueria-vscode-extension/node_modules /s /e
+        run: xcopy node_modules taqueria-vscode-extension\node_modules /s /e
         if: runner.os == 'Windows'
       
       - name: Package VSCode Extension

--- a/package-lock.json
+++ b/package-lock.json
@@ -2753,6 +2753,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -3606,6 +3611,21 @@
         "node": ">= 10"
       }
     },
+    "node_modules/comment-json": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.1.tgz",
+      "integrity": "sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.2",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3703,8 +3723,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -4452,39 +4471,42 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.14.tgz",
-      "integrity": "sha512-aiK4ddv+uui0k52OqSHu4xxu+SzOim7Rlz4i25pMEiC8rlnGU0HJ9r+ZMfdWL5bzifg+nhnn7x4NSWTeehYblg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.15.tgz",
+      "integrity": "sha512-HfqoMPCSwu/VrHwZFpw7Sb/w9D9mO+cSMfFRKGZKOkme/o5nHdWjF6H5Ss1cOt/JNpqJfGOYbKFbW7jKdEWogw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
+      "engines": {
+        "node": ">=12"
+      },
       "optionalDependencies": {
-        "esbuild-android-arm64": "0.14.14",
-        "esbuild-darwin-64": "0.14.14",
-        "esbuild-darwin-arm64": "0.14.14",
-        "esbuild-freebsd-64": "0.14.14",
-        "esbuild-freebsd-arm64": "0.14.14",
-        "esbuild-linux-32": "0.14.14",
-        "esbuild-linux-64": "0.14.14",
-        "esbuild-linux-arm": "0.14.14",
-        "esbuild-linux-arm64": "0.14.14",
-        "esbuild-linux-mips64le": "0.14.14",
-        "esbuild-linux-ppc64le": "0.14.14",
-        "esbuild-linux-s390x": "0.14.14",
-        "esbuild-netbsd-64": "0.14.14",
-        "esbuild-openbsd-64": "0.14.14",
-        "esbuild-sunos-64": "0.14.14",
-        "esbuild-windows-32": "0.14.14",
-        "esbuild-windows-64": "0.14.14",
-        "esbuild-windows-arm64": "0.14.14"
+        "esbuild-android-arm64": "0.14.15",
+        "esbuild-darwin-64": "0.14.15",
+        "esbuild-darwin-arm64": "0.14.15",
+        "esbuild-freebsd-64": "0.14.15",
+        "esbuild-freebsd-arm64": "0.14.15",
+        "esbuild-linux-32": "0.14.15",
+        "esbuild-linux-64": "0.14.15",
+        "esbuild-linux-arm": "0.14.15",
+        "esbuild-linux-arm64": "0.14.15",
+        "esbuild-linux-mips64le": "0.14.15",
+        "esbuild-linux-ppc64le": "0.14.15",
+        "esbuild-linux-s390x": "0.14.15",
+        "esbuild-netbsd-64": "0.14.15",
+        "esbuild-openbsd-64": "0.14.15",
+        "esbuild-sunos-64": "0.14.15",
+        "esbuild-windows-32": "0.14.15",
+        "esbuild-windows-64": "0.14.15",
+        "esbuild-windows-arm64": "0.14.15"
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.14.tgz",
-      "integrity": "sha512-be/Uw6DdpQiPfula1J4bdmA+wtZ6T3BRCZsDMFB5X+k0Gp8TIh9UvmAcqvKNnbRAafSaXG3jPCeXxDKqnc8hFQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.15.tgz",
+      "integrity": "sha512-MXfSrLpK32SqJXGvNOQmUbs06K+kFtZg8uNBcxrsvxDjjI42EXerq+QGdD3zQO1RzbqU1W7c15qAoeQOzwKJxA==",
       "cpu": [
         "arm64"
       ],
@@ -4492,12 +4514,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.14.tgz",
-      "integrity": "sha512-BEexYmjWafcISK8cT6O98E3TfcLuZL8DKuubry6G54n2+bD4GkoRD6HYUOnCkfl2p7jodA+s4369IjSFSWjtHg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.15.tgz",
+      "integrity": "sha512-leGh21rMfhZq0Rq5Y5xwuhFW6cJ5lxIkTfHSBWtXjicwD5bHACRonaKqcSQRQtUnjfd6mQUdNPH47DOg6ACHLA==",
       "cpu": [
         "x64"
       ],
@@ -4505,12 +4530,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.14.tgz",
-      "integrity": "sha512-tnBKm41pDOB1GtZ8q/w26gZlLLRzVmP8fdsduYjvM+yFD7E2DLG4KbPAqFMWm4Md9B+DitBglP57FY7AznxbTg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.15.tgz",
+      "integrity": "sha512-W0e16PACxu/iYpRtSq8fijelsZhKy99uDZEBwtoqEpLF2KZD5/Sz9IfwaVDqm/Q3yEqrf30TGbIJoMc9KNakuQ==",
       "cpu": [
         "arm64"
       ],
@@ -4518,12 +4546,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.14.tgz",
-      "integrity": "sha512-Q9Rx6sgArOHalQtNwAaIzJ6dnQ8A+I7f/RsQsdkS3JrdzmnlFo8JEVofTmwVQLoIop7OKUqIVOGP4PoQcwfVMA==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.15.tgz",
+      "integrity": "sha512-heArH9Z0j9WUJd5zLMSnEZ5eJv0iyJpHNOfDqJyFWMic1UNiD5Akpwfhs+4/zNNf8zKjovmBMQyfbd4i2UyrtA==",
       "cpu": [
         "x64"
       ],
@@ -4531,12 +4562,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.14.tgz",
-      "integrity": "sha512-TJvq0OpLM7BkTczlyPIphcvnwrQwQDG1HqxzoYePWn26SMUAlt6wrLnEvxdbXAvNvDLVzG83kA+JimjK7aRNBA==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.15.tgz",
+      "integrity": "sha512-B9ZR1WXCTSKef9br2SeyKkFqd0xCkOu/alJxdiXs7QnYqydvYmr8LHAW/kq9fufCU3XUzKNr6kKMg4a61yxZsg==",
       "cpu": [
         "arm64"
       ],
@@ -4544,12 +4578,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.14.tgz",
-      "integrity": "sha512-h/CrK9Baimt5VRbu8gqibWV7e1P9l+mkanQgyOgv0Ng3jHT1NVFC9e6rb1zbDdaJVmuhWX5xVliUA5bDDCcJeg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.15.tgz",
+      "integrity": "sha512-vmClHfPbQCt+E388OTp1b8mo6SnU63ARwlCise/IZZ5XzbAP9Oi3SCCDpZTpLJl0df0bu5xcagZo8fJt1O/3lg==",
       "cpu": [
         "ia32"
       ],
@@ -4557,12 +4594,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.14.tgz",
-      "integrity": "sha512-IC+wAiIg/egp5OhQp4W44D9PcBOH1b621iRn1OXmlLzij9a/6BGr9NMIL4CRwz4j2kp3WNZu5sT473tYdynOuQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.15.tgz",
+      "integrity": "sha512-iQLc0KVOYZD7NL5UWrox6hhlE4Jr4mF2xi2EaBR/ntR1T9PUvUrz7hdKiWos8Wtv5Ma05tt+HBRKOmseSTc5Gg==",
       "cpu": [
         "x64"
       ],
@@ -4570,12 +4610,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.14.tgz",
-      "integrity": "sha512-gxpOaHOPwp7zSmcKYsHrtxabScMqaTzfSQioAMUaB047YiMuDBzqVcKBG8OuESrYkGrL9DDljXr/mQNg7pbdaQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.15.tgz",
+      "integrity": "sha512-rMzfdyZTsg27GbWSc2v/z1OVjrPsWAr8zOPkk/6SX4qrChzd3jxw19gLKm/SMfy5lZfkOFfqJhAuInRg+6/KJg==",
       "cpu": [
         "arm"
       ],
@@ -4583,12 +4626,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.14.tgz",
-      "integrity": "sha512-6QVul3RI4M5/VxVIRF/I5F+7BaxzR3DfNGoqEVSCZqUbgzHExPn+LXr5ly1C7af2Kw4AHpo+wDqx8A4ziP9avw==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.15.tgz",
+      "integrity": "sha512-OCqCON/ZQBGa0dfqNJ86fSa6zTO0MOR7lT+UGoKShx6G74WuEuTA2HrlOShcCSHr8Ttzc0AoGJJHhZ9ZRNWsPQ==",
       "cpu": [
         "arm64"
       ],
@@ -4596,12 +4642,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.14.tgz",
-      "integrity": "sha512-4Jl5/+xoINKbA4cesH3f4R+q0vltAztZ6Jm8YycS8lNhN1pgZJBDxWfI6HUMIAdkKlIpR1PIkA9aXQgZ8sxFAg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.15.tgz",
+      "integrity": "sha512-ODngnCio7L5pW9hYRdX3fZRw8HrlBm+MDU7hCgZK8kvZz35ba3mt4brKtCDwD98UFP89JYSSNQIsP2xLH/M/Sg==",
       "cpu": [
         "mips64el"
       ],
@@ -4609,12 +4658,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.14.tgz",
-      "integrity": "sha512-BitW37GxeebKxqYNl4SVuSdnIJAzH830Lr6Mkq3pBHXtzQay0vK+IeOR/Ele1GtNVJ+/f8wYM53tcThkv5SC5w==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.15.tgz",
+      "integrity": "sha512-9ubsGxM0qNWNVds5qCEWBRuxNeDFDJeTylsZsIo30pMy8rdgR5awNmHJalBg9qIS8nsPmFkTRqAo1hZlOIpZGQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4622,12 +4674,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.14.tgz",
-      "integrity": "sha512-vLj6p76HOZG3wfuTr5MyO3qW5iu8YdhUNxuY+tx846rPo7GcKtYSPMusQjeVEfZlJpSYoR+yrNBBxq+qVF9zrw==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.15.tgz",
+      "integrity": "sha512-F92Ca0EqpidlnobeTyCIWtgKangl7TQRByTeQMwraQUUPpwuSS0qN2APQAgwabhtF7ANxVY7UGlUIqNVApVz7Q==",
       "cpu": [
         "s390x"
       ],
@@ -4635,12 +4690,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.14.tgz",
-      "integrity": "sha512-fn8looXPQhpVqUyCBWUuPjesH+yGIyfbIQrLKG05rr1Kgm3rZD/gaYrd3Wpmf5syVZx70pKZPvdHp8OTA+y7cQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.15.tgz",
+      "integrity": "sha512-jk+lgFOQL0ja1zrygM0r7oQQMKj5TTvALI30qk7yAxodcT9fNebschedJfAha6Up5sdGEe/32Gu4yb4xagmEJA==",
       "cpu": [
         "x64"
       ],
@@ -4648,12 +4706,15 @@
       "optional": true,
       "os": [
         "netbsd"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.14.tgz",
-      "integrity": "sha512-HdAnJ399pPff3SKbd8g+P4o5znseni5u5n5rJ6Z7ouqOdgbOwHe2ofZbMow17WMdNtz1IyOZk2Wo9Ve6/lZ4Rg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.15.tgz",
+      "integrity": "sha512-jXMvH4UMZkFfzioifOxiSC/7PuxyJD3EXrWIhqsHsmjuCs5hreuo9aA3oIlIjk5D9AqHsXS50JrUGG1VAz4mPw==",
       "cpu": [
         "x64"
       ],
@@ -4661,12 +4722,15 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.14.tgz",
-      "integrity": "sha512-bmDHa99ulsGnYlh/xjBEfxoGuC8CEG5OWvlgD+pF7bKKiVTbtxqVCvOGEZeoDXB+ja6AvHIbPxrEE32J+m5nqQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.15.tgz",
+      "integrity": "sha512-J8JsJ/Kg9U3hnKdAmRkDVVR215kYuNWlINgYeCSqNayqRi6+lc41DHxsoV2k048YYLHIn9mTWH0xS3BPUJzKXA==",
       "cpu": [
         "x64"
       ],
@@ -4674,12 +4738,15 @@
       "optional": true,
       "os": [
         "sunos"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.14.tgz",
-      "integrity": "sha512-6tVooQcxJCNenPp5GHZBs/RLu31q4B+BuF4MEoRxswT+Eq2JGF0ZWDRQwNKB8QVIo3t6Svc5wNGez+CwKNQjBg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.15.tgz",
+      "integrity": "sha512-S6tkET6DXg8mM+2yYutC1JQeS4EtztU6GTE0ff9tHoZekdc91n2LUChmZvHbTI0MZDBy+hYgc9f7pVbVqbEL0g==",
       "cpu": [
         "ia32"
       ],
@@ -4687,12 +4754,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.14.tgz",
-      "integrity": "sha512-kl3BdPXh0/RD/dad41dtzj2itMUR4C6nQbXQCyYHHo4zoUoeIXhpCrSl7BAW1nv5EFL8stT1V+TQVXGZca5A2A==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.15.tgz",
+      "integrity": "sha512-xi5SfDNKXL6D98vEnCa0Wq35ULPTkypHOGzBwsSBhmv1+k3YeuwXNxyJLumElibfTZGVSEmH+hhCjCEPbeJgrg==",
       "cpu": [
         "x64"
       ],
@@ -4700,12 +4770,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.14.tgz",
-      "integrity": "sha512-dCm1wTOm6HIisLanmybvRKvaXZZo4yEVrHh1dY0v582GThXJOzuXGja1HIQgV09RpSHYRL3m4KoUBL00l6SWEg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.15.tgz",
+      "integrity": "sha512-ylLqTXQoj87OMejTajYOpBXCCxkHo5CpFnDztPZZ34QPGyzUpd4+R4H8hW37GhwywU1Fu5/typBD+AbKe1PwFQ==",
       "cpu": [
         "arm64"
       ],
@@ -4713,7 +4786,10 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -4876,6 +4952,18 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -5590,6 +5678,14 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "engines": {
         "node": ">=8"
       }
@@ -6530,11 +6626,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
@@ -8499,6 +8590,14 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -10154,7 +10253,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@taqueria/protocol": "^0.0.5",
-        "jsonc-parser": "^3.0.0",
+        "comment-json": "^4.1.1",
         "promise-memoize": "^1.2.1",
         "rambda": "^7.0.1"
       },
@@ -10167,6 +10266,7 @@
         "@typescript-eslint/eslint-plugin": "^5.9.1",
         "@typescript-eslint/parser": "^5.9.1",
         "@vscode/test-electron": "^2.0.3",
+        "esbuild": "^0.14.15",
         "eslint": "^8.6.0",
         "glob": "^7.2.0",
         "mocha": "^9.1.3",
@@ -12226,6 +12326,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -12902,6 +13007,18 @@
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true
     },
+    "comment-json": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.1.tgz",
+      "integrity": "sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==",
+      "requires": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.2",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -12992,8 +13109,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -13575,154 +13691,154 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.14.tgz",
-      "integrity": "sha512-aiK4ddv+uui0k52OqSHu4xxu+SzOim7Rlz4i25pMEiC8rlnGU0HJ9r+ZMfdWL5bzifg+nhnn7x4NSWTeehYblg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.15.tgz",
+      "integrity": "sha512-HfqoMPCSwu/VrHwZFpw7Sb/w9D9mO+cSMfFRKGZKOkme/o5nHdWjF6H5Ss1cOt/JNpqJfGOYbKFbW7jKdEWogw==",
       "dev": true,
       "requires": {
-        "esbuild-android-arm64": "0.14.14",
-        "esbuild-darwin-64": "0.14.14",
-        "esbuild-darwin-arm64": "0.14.14",
-        "esbuild-freebsd-64": "0.14.14",
-        "esbuild-freebsd-arm64": "0.14.14",
-        "esbuild-linux-32": "0.14.14",
-        "esbuild-linux-64": "0.14.14",
-        "esbuild-linux-arm": "0.14.14",
-        "esbuild-linux-arm64": "0.14.14",
-        "esbuild-linux-mips64le": "0.14.14",
-        "esbuild-linux-ppc64le": "0.14.14",
-        "esbuild-linux-s390x": "0.14.14",
-        "esbuild-netbsd-64": "0.14.14",
-        "esbuild-openbsd-64": "0.14.14",
-        "esbuild-sunos-64": "0.14.14",
-        "esbuild-windows-32": "0.14.14",
-        "esbuild-windows-64": "0.14.14",
-        "esbuild-windows-arm64": "0.14.14"
+        "esbuild-android-arm64": "0.14.15",
+        "esbuild-darwin-64": "0.14.15",
+        "esbuild-darwin-arm64": "0.14.15",
+        "esbuild-freebsd-64": "0.14.15",
+        "esbuild-freebsd-arm64": "0.14.15",
+        "esbuild-linux-32": "0.14.15",
+        "esbuild-linux-64": "0.14.15",
+        "esbuild-linux-arm": "0.14.15",
+        "esbuild-linux-arm64": "0.14.15",
+        "esbuild-linux-mips64le": "0.14.15",
+        "esbuild-linux-ppc64le": "0.14.15",
+        "esbuild-linux-s390x": "0.14.15",
+        "esbuild-netbsd-64": "0.14.15",
+        "esbuild-openbsd-64": "0.14.15",
+        "esbuild-sunos-64": "0.14.15",
+        "esbuild-windows-32": "0.14.15",
+        "esbuild-windows-64": "0.14.15",
+        "esbuild-windows-arm64": "0.14.15"
       }
     },
     "esbuild-android-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.14.tgz",
-      "integrity": "sha512-be/Uw6DdpQiPfula1J4bdmA+wtZ6T3BRCZsDMFB5X+k0Gp8TIh9UvmAcqvKNnbRAafSaXG3jPCeXxDKqnc8hFQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.15.tgz",
+      "integrity": "sha512-MXfSrLpK32SqJXGvNOQmUbs06K+kFtZg8uNBcxrsvxDjjI42EXerq+QGdD3zQO1RzbqU1W7c15qAoeQOzwKJxA==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.14.tgz",
-      "integrity": "sha512-BEexYmjWafcISK8cT6O98E3TfcLuZL8DKuubry6G54n2+bD4GkoRD6HYUOnCkfl2p7jodA+s4369IjSFSWjtHg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.15.tgz",
+      "integrity": "sha512-leGh21rMfhZq0Rq5Y5xwuhFW6cJ5lxIkTfHSBWtXjicwD5bHACRonaKqcSQRQtUnjfd6mQUdNPH47DOg6ACHLA==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.14.tgz",
-      "integrity": "sha512-tnBKm41pDOB1GtZ8q/w26gZlLLRzVmP8fdsduYjvM+yFD7E2DLG4KbPAqFMWm4Md9B+DitBglP57FY7AznxbTg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.15.tgz",
+      "integrity": "sha512-W0e16PACxu/iYpRtSq8fijelsZhKy99uDZEBwtoqEpLF2KZD5/Sz9IfwaVDqm/Q3yEqrf30TGbIJoMc9KNakuQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.14.tgz",
-      "integrity": "sha512-Q9Rx6sgArOHalQtNwAaIzJ6dnQ8A+I7f/RsQsdkS3JrdzmnlFo8JEVofTmwVQLoIop7OKUqIVOGP4PoQcwfVMA==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.15.tgz",
+      "integrity": "sha512-heArH9Z0j9WUJd5zLMSnEZ5eJv0iyJpHNOfDqJyFWMic1UNiD5Akpwfhs+4/zNNf8zKjovmBMQyfbd4i2UyrtA==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.14.tgz",
-      "integrity": "sha512-TJvq0OpLM7BkTczlyPIphcvnwrQwQDG1HqxzoYePWn26SMUAlt6wrLnEvxdbXAvNvDLVzG83kA+JimjK7aRNBA==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.15.tgz",
+      "integrity": "sha512-B9ZR1WXCTSKef9br2SeyKkFqd0xCkOu/alJxdiXs7QnYqydvYmr8LHAW/kq9fufCU3XUzKNr6kKMg4a61yxZsg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.14.tgz",
-      "integrity": "sha512-h/CrK9Baimt5VRbu8gqibWV7e1P9l+mkanQgyOgv0Ng3jHT1NVFC9e6rb1zbDdaJVmuhWX5xVliUA5bDDCcJeg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.15.tgz",
+      "integrity": "sha512-vmClHfPbQCt+E388OTp1b8mo6SnU63ARwlCise/IZZ5XzbAP9Oi3SCCDpZTpLJl0df0bu5xcagZo8fJt1O/3lg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.14.tgz",
-      "integrity": "sha512-IC+wAiIg/egp5OhQp4W44D9PcBOH1b621iRn1OXmlLzij9a/6BGr9NMIL4CRwz4j2kp3WNZu5sT473tYdynOuQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.15.tgz",
+      "integrity": "sha512-iQLc0KVOYZD7NL5UWrox6hhlE4Jr4mF2xi2EaBR/ntR1T9PUvUrz7hdKiWos8Wtv5Ma05tt+HBRKOmseSTc5Gg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.14.tgz",
-      "integrity": "sha512-gxpOaHOPwp7zSmcKYsHrtxabScMqaTzfSQioAMUaB047YiMuDBzqVcKBG8OuESrYkGrL9DDljXr/mQNg7pbdaQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.15.tgz",
+      "integrity": "sha512-rMzfdyZTsg27GbWSc2v/z1OVjrPsWAr8zOPkk/6SX4qrChzd3jxw19gLKm/SMfy5lZfkOFfqJhAuInRg+6/KJg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.14.tgz",
-      "integrity": "sha512-6QVul3RI4M5/VxVIRF/I5F+7BaxzR3DfNGoqEVSCZqUbgzHExPn+LXr5ly1C7af2Kw4AHpo+wDqx8A4ziP9avw==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.15.tgz",
+      "integrity": "sha512-OCqCON/ZQBGa0dfqNJ86fSa6zTO0MOR7lT+UGoKShx6G74WuEuTA2HrlOShcCSHr8Ttzc0AoGJJHhZ9ZRNWsPQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.14.tgz",
-      "integrity": "sha512-4Jl5/+xoINKbA4cesH3f4R+q0vltAztZ6Jm8YycS8lNhN1pgZJBDxWfI6HUMIAdkKlIpR1PIkA9aXQgZ8sxFAg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.15.tgz",
+      "integrity": "sha512-ODngnCio7L5pW9hYRdX3fZRw8HrlBm+MDU7hCgZK8kvZz35ba3mt4brKtCDwD98UFP89JYSSNQIsP2xLH/M/Sg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.14.tgz",
-      "integrity": "sha512-BitW37GxeebKxqYNl4SVuSdnIJAzH830Lr6Mkq3pBHXtzQay0vK+IeOR/Ele1GtNVJ+/f8wYM53tcThkv5SC5w==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.15.tgz",
+      "integrity": "sha512-9ubsGxM0qNWNVds5qCEWBRuxNeDFDJeTylsZsIo30pMy8rdgR5awNmHJalBg9qIS8nsPmFkTRqAo1hZlOIpZGQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.14.tgz",
-      "integrity": "sha512-vLj6p76HOZG3wfuTr5MyO3qW5iu8YdhUNxuY+tx846rPo7GcKtYSPMusQjeVEfZlJpSYoR+yrNBBxq+qVF9zrw==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.15.tgz",
+      "integrity": "sha512-F92Ca0EqpidlnobeTyCIWtgKangl7TQRByTeQMwraQUUPpwuSS0qN2APQAgwabhtF7ANxVY7UGlUIqNVApVz7Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.14.tgz",
-      "integrity": "sha512-fn8looXPQhpVqUyCBWUuPjesH+yGIyfbIQrLKG05rr1Kgm3rZD/gaYrd3Wpmf5syVZx70pKZPvdHp8OTA+y7cQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.15.tgz",
+      "integrity": "sha512-jk+lgFOQL0ja1zrygM0r7oQQMKj5TTvALI30qk7yAxodcT9fNebschedJfAha6Up5sdGEe/32Gu4yb4xagmEJA==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.14.tgz",
-      "integrity": "sha512-HdAnJ399pPff3SKbd8g+P4o5znseni5u5n5rJ6Z7ouqOdgbOwHe2ofZbMow17WMdNtz1IyOZk2Wo9Ve6/lZ4Rg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.15.tgz",
+      "integrity": "sha512-jXMvH4UMZkFfzioifOxiSC/7PuxyJD3EXrWIhqsHsmjuCs5hreuo9aA3oIlIjk5D9AqHsXS50JrUGG1VAz4mPw==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.14.tgz",
-      "integrity": "sha512-bmDHa99ulsGnYlh/xjBEfxoGuC8CEG5OWvlgD+pF7bKKiVTbtxqVCvOGEZeoDXB+ja6AvHIbPxrEE32J+m5nqQ==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.15.tgz",
+      "integrity": "sha512-J8JsJ/Kg9U3hnKdAmRkDVVR215kYuNWlINgYeCSqNayqRi6+lc41DHxsoV2k048YYLHIn9mTWH0xS3BPUJzKXA==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.14.tgz",
-      "integrity": "sha512-6tVooQcxJCNenPp5GHZBs/RLu31q4B+BuF4MEoRxswT+Eq2JGF0ZWDRQwNKB8QVIo3t6Svc5wNGez+CwKNQjBg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.15.tgz",
+      "integrity": "sha512-S6tkET6DXg8mM+2yYutC1JQeS4EtztU6GTE0ff9tHoZekdc91n2LUChmZvHbTI0MZDBy+hYgc9f7pVbVqbEL0g==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.14.tgz",
-      "integrity": "sha512-kl3BdPXh0/RD/dad41dtzj2itMUR4C6nQbXQCyYHHo4zoUoeIXhpCrSl7BAW1nv5EFL8stT1V+TQVXGZca5A2A==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.15.tgz",
+      "integrity": "sha512-xi5SfDNKXL6D98vEnCa0Wq35ULPTkypHOGzBwsSBhmv1+k3YeuwXNxyJLumElibfTZGVSEmH+hhCjCEPbeJgrg==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.14.tgz",
-      "integrity": "sha512-dCm1wTOm6HIisLanmybvRKvaXZZo4yEVrHh1dY0v582GThXJOzuXGja1HIQgV09RpSHYRL3m4KoUBL00l6SWEg==",
+      "version": "0.14.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.15.tgz",
+      "integrity": "sha512-ylLqTXQoj87OMejTajYOpBXCCxkHo5CpFnDztPZZ34QPGyzUpd4+R4H8hW37GhwywU1Fu5/typBD+AbKe1PwFQ==",
       "dev": true,
       "optional": true
     },
@@ -13847,6 +13963,11 @@
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^3.1.0"
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -14408,6 +14529,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -15053,11 +15179,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
     },
     "jsprim": {
       "version": "1.4.2",
@@ -16522,6 +16643,11 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -16985,9 +17111,10 @@
         "@typescript-eslint/eslint-plugin": "^5.9.1",
         "@typescript-eslint/parser": "^5.9.1",
         "@vscode/test-electron": "^2.0.3",
+        "comment-json": "^4.1.1",
+        "esbuild": "^0.14.15",
         "eslint": "^8.6.0",
         "glob": "^7.2.0",
-        "jsonc-parser": "^3.0.0",
         "mocha": "^9.1.3",
         "promise-memoize": "^1.2.1",
         "rambda": "^7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@taqueria/taqueria",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@taqueria/taqueria",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "Apache-2.0",
       "workspaces": [
         "./taqueria*"
@@ -3721,9 +3721,9 @@
       }
     },
     "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -9727,6 +9727,12 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -10156,7 +10162,6 @@
       }
     },
     "taqueria-plugin-flextesa": {
-      "name": "@taqueria/plugin-flextesa",
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
@@ -10171,7 +10176,6 @@
       }
     },
     "taqueria-plugin-ligo": {
-      "name": "@taqueria/plugin-ligo",
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
@@ -10180,7 +10184,6 @@
       }
     },
     "taqueria-plugin-mock": {
-      "name": "@taqueria/plugin-mock",
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
@@ -10188,7 +10191,6 @@
       }
     },
     "taqueria-plugin-smartpy": {
-      "name": "@taqueria/plugin-smartpy",
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
@@ -10201,7 +10203,6 @@
       }
     },
     "taqueria-plugin-taquito": {
-      "name": "@taqueria/plugin-taquito",
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
@@ -10216,7 +10217,6 @@
       }
     },
     "taqueria-protocol": {
-      "name": "@taqueria/protocol",
       "version": "0.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -10224,7 +10224,6 @@
       }
     },
     "taqueria-sdk": {
-      "name": "@taqueria/node-sdk",
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
@@ -10248,7 +10247,6 @@
       }
     },
     "taqueria-vscode-extension": {
-      "name": "taqueria-vscode",
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
@@ -13107,9 +13105,9 @@
       "dev": true
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -17532,6 +17530,14 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        }
       }
     },
     "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taqueria/taqueria",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "An easy to use opininated tool for building, testing, and deploying Tezos software",
   "main": "index.ts",
   "directories": {

--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -105,7 +105,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "npx esbuild --bundle src/extension.ts --external:vscode --format=cjs --outfile=out/extension.js --minify --platform=node --sourcemap",
+    "compile": "tsc -p ./ && npx esbuild --bundle src/extension.ts --external:vscode --format=cjs --outfile=out/extension.js --minify --platform=node --sourcemap",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",

--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -105,7 +105,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "compile": "npx esbuild --bundle src/extension.ts --external:vscode --format=cjs --outfile=out/extension.js --minify --platform=node --sourcemap",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
@@ -120,6 +120,7 @@
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
     "@vscode/test-electron": "^2.0.3",
+    "esbuild": "^0.14.15",
     "eslint": "^8.6.0",
     "glob": "^7.2.0",
     "mocha": "^9.1.3",
@@ -128,7 +129,7 @@
   },
   "dependencies": {
     "@taqueria/protocol": "^0.0.5",
-    "jsonc-parser": "^3.0.0",
+    "comment-json": "^4.1.1",
     "promise-memoize": "^1.2.1",
     "rambda": "^7.0.1"
   }

--- a/taqueria-vscode-extension/src/lib/pure.ts
+++ b/taqueria-vscode-extension/src/lib/pure.ts
@@ -229,7 +229,7 @@ export const makePathToTaq = (i18n: I18N) => (inputPath: string) : PromiseLike<E
  * @returns {PromiseLike<E_EXEC, string>}
  */        
 export const execCmd = (cmd: string): PromiseLike<E_EXEC, string> => new Promise((resolve, reject) => {
-    exec(`sh -c '${cmd}'`, (previous, stdout, msg) => {
+    exec(isWindoze() ? cmd : `sh -c '${cmd}'`, (previous, stdout, msg) => {
         log ("Executing command:") (cmd)
         if (previous) reject({code: 'E_EXEC', msg: `An unexpected error occurred when trying to execute the command`, previous, cmd})
         else if (msg.length) reject({code: 'E_EXEC', msg, cmd})
@@ -292,8 +292,10 @@ export const decodeJson = <T>(data: string): PromiseLike<E_INVALID_JSON, Json<T>
     }
 }
 
+export const isWindoze = () => process.platform.includes('win')
+
 export const findTaqBinary = (i18n: I18N) : PromiseLike<E_TAQ_NOT_FOUND, string> =>
-    execCmd('which taq')
+    execCmd(isWindoze() ? 'where taq' : 'which taq')
     .then(path => path.trim())
     .catch(previous => Promise.reject({code: 'E_TAQ_NOT_FOUND', msg: "Could not find taq in your path.", previous}))
     .then(makePathToTaq(i18n))

--- a/taqueria-vscode-extension/src/lib/pure.ts
+++ b/taqueria-vscode-extension/src/lib/pure.ts
@@ -2,7 +2,7 @@ import {exec} from 'child_process'
 import {stat, readFile} from 'fs/promises'
 import {join} from 'path'
 import {Config} from '@taqueria/protocol/taqueria-protocol-types'
-import {parse} from 'jsonc-parser'
+import {parse} from 'comment-json'
 
 
 /***********************************************************************/
@@ -292,7 +292,7 @@ export const decodeJson = <T>(data: string): PromiseLike<E_INVALID_JSON, Json<T>
     }
 }
 
-export const isWindoze = () => process.platform.includes('win')
+export const isWindoze = () => true // process.platform.includes('win')
 
 export const findTaqBinary = (i18n: I18N) : PromiseLike<E_TAQ_NOT_FOUND, string> =>
     execCmd(isWindoze() ? 'where taq' : 'which taq')

--- a/taqueria-vscode-extension/src/lib/pure.ts
+++ b/taqueria-vscode-extension/src/lib/pure.ts
@@ -229,7 +229,7 @@ export const makePathToTaq = (i18n: I18N) => (inputPath: string) : PromiseLike<E
  * @returns {PromiseLike<E_EXEC, string>}
  */        
 export const execCmd = (cmd: string): PromiseLike<E_EXEC, string> => new Promise((resolve, reject) => {
-    exec(isWindoze() ? cmd : `sh -c '${cmd}'`, (previous, stdout, msg) => {
+    exec(cmd, (previous, stdout, msg) => {
         log ("Executing command:") (cmd)
         if (previous) reject({code: 'E_EXEC', msg: `An unexpected error occurred when trying to execute the command`, previous, cmd})
         else if (msg.length) reject({code: 'E_EXEC', msg, cmd})
@@ -292,7 +292,7 @@ export const decodeJson = <T>(data: string): PromiseLike<E_INVALID_JSON, Json<T>
     }
 }
 
-export const isWindoze = () => true // process.platform.includes('win')
+export const isWindoze = () => process.platform.includes('win')
 
 export const findTaqBinary = (i18n: I18N) : PromiseLike<E_TAQ_NOT_FOUND, string> =>
     execCmd(isWindoze() ? 'where taq' : 'which taq')


### PR DESCRIPTION
VSCode package requires node_modules to be included in the VXIS package, but now that we're using NPM workspaces, I believe that node_modules is in the root of the repo.

So I'm copying node_modules from the root before packaging.

In addition, the VSCode extension runs some child processes which need some adjustment to work on Windows.