### PR TITLE
feat(ci): flexesa docker image on multiple platforms

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,11 +52,21 @@ jobs:
       - name: Build package
         run: npm run build -w taqueria-plugin-flextesa/docker
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/arm64,linux/amd64,linux/arm64/v8
+          platforms: linux/arm64,linux/arm64
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/arm64,linux/amd64,linux/arm64/v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: linux/arm64
+          platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64,linux/arm64v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: all
+          platforms: linux/arm64/v8
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/arm64,linux/arm64/v8
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/arm64,linux/arm64/v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm64v8
+          platforms: linux/amd64,linux/arm64/v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: linux/arm64/v8
+          platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/arm64/v8
+          platforms: linux/arm64,linux/amd64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: linux/amd64,linux/arm64/v7
+          platforms: linux/amd64,linux/arm64/v8
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64/v7
+          platforms: linux/amd64,linux/arm64/v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 
@@ -80,5 +80,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'The latest docker name:tag for this PR is ***${{ steps.image-metadata.outputs.tags }}*** :whale: :ship:'
+              body: 'The latest docker name:tag for this PR is ***${{ steps.image-metadata.outputs.tags }}*** :whale: :ship:. The image is available for the following platforms: `linux/amd64` and `linux/arm64/v8`'
             })

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64/v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/arm64,linux/arm64
+          platforms: linux/arm64/v8
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: linux/arm64,linux/arm64/v8
+          platforms: linux/arm64
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/arm64,linux/arm64/v8
+          platforms: linux/arm64
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v7
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v7
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
-          platforms: all
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         id: buildx
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ./taqueria-plugin-flextesa/docker/
           push: true
-          platforms: linux/arm64,linux/amd64,linux/arm/v7,linux/arm/v6
+          platforms: linux/arm64/v8,linux/amd64
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
 

--- a/taqueria-plugin-flextesa/docker/Dockerfile
+++ b/taqueria-plugin-flextesa/docker/Dockerfile
@@ -4,4 +4,3 @@ WORKDIR /app
 COPY startFlextesa.js /app/
 RUN apk add net-tools nodejs npm
 CMD node /app/startFlextesa.js
-#

--- a/taqueria-plugin-flextesa/docker/Dockerfile
+++ b/taqueria-plugin-flextesa/docker/Dockerfile
@@ -4,3 +4,4 @@ WORKDIR /app
 COPY startFlextesa.js /app/
 RUN apk add net-tools nodejs npm
 CMD node /app/startFlextesa.js
+#


### PR DESCRIPTION
Publishing docker images for `linux/amd64` and `linux/arm64/v8`

**Testing Plan**
Please see the [taqueria-flextesa](https://github.com/ecadlabs/taqueria/pkgs/container/taqueria-flextesa) images.

![image](https://user-images.githubusercontent.com/29157965/152843634-95782065-ee37-420c-9601-d5d252dbd552.png)

**Note**
We found that `linux/arm64` and `linux/arm64/v8` are essentially the same platform and will work for both if only one is specified.

Ref #206