### PR TITLE
ci(vscode): publish to VSCode marketplace when a GH release is published

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -7,8 +7,8 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - '**'
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -7,6 +7,8 @@ on:
   push:
     tags:
       - v*
+    branches:
+      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -71,6 +71,7 @@ jobs:
           dryRun: true
           yarn: true
           packagePath: ${{ env.GIT_WORKSPACE }}
+          preRelease: true
       - id: setArtifactFilename
         if: runner.os == 'Linux'
         run: echo "::set-output name=filename::taqueria-vscode-${{ github.head_ref || github.ref_name }}-${{ runner.os }}"
@@ -84,7 +85,7 @@ jobs:
 
   publish-marketplace:
     name: Publish VSCode Extension
-    if: github.ref_type == 'tag'
+    if: ${{ !github.event.release.prerelease && github.event.action == 'published' }}
     needs:
       - lint-test-build
     runs-on: ubuntu-latest

--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "taqueria-vscode",
+  "name": "taqueria-vscode-dev",
   "displayName": "taqueria",
   "description": "A vscode plugin to make Tezos development easier with Taqueria!",
   "publisher": "ecadlabs",

--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "taqueria-vscode-dev",
+  "name": "taqueria-vscode",
   "displayName": "taqueria",
   "description": "A vscode plugin to make Tezos development easier with Taqueria!",
   "publisher": "ecadlabs",


### PR DESCRIPTION
## Summary
Similar to #185  we want to publish the VSCode Extension to the marketplace only when we officially publish a release on GH. 

The extension now is also being flagged as `pre-release` on the marketplace

![Screenshot from 2022-02-07 11-22-14](https://user-images.githubusercontent.com/22307776/152857254-158c6a0b-3e9b-4c97-9dad-35fb5b176de0.png)


## Test Plan
Triggered a GH release to test the changes. Tha VSCode Extension isn't published anymore when a tag is pushed to `main` as the publishing job is skipped. https://github.com/ecadlabs/taqueria/actions/runs/1808354127
![Screenshot from 2022-02-07 11-17-57](https://user-images.githubusercontent.com/22307776/152856649-47a38bc5-a31c-4dbf-8394-1c16a4f04760.png)

The extension is published to the VSCode marketplace when a GH release is published publicly.
https://github.com/ecadlabs/taqueria/actions/runs/1808354127 
![Screenshot from 2022-02-07 11-19-04](https://user-images.githubusercontent.com/22307776/152856896-2446689c-39e1-4887-b858-3535cfda4ad4.png)


