### PR TITLE
Fixes #273, LIGO compilation failures on Apple Silicon

### DIFF
--- a/taqueria-plugin-ligo/compile.js
+++ b/taqueria-plugin-ligo/compile.js
@@ -14,7 +14,7 @@ const getInputFilename = (opts) => sourceFile => {
 const getCompileCommand = (opts, _arch) => (sourceFile) => {
     const {projectDir} = opts
     const inputFile = getInputFilename (opts) (sourceFile)
-    const baseCommand = `docker run --rm -v \"${projectDir}\":/project -w /project ligolang/ligo:next compile contract ${inputFile}`
+    const baseCommand = `DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project ligolang/ligo:next compile contract ${inputFile}`
     const entryPoint = opts.e ? `-e ${opts.e}` : ""
     const syntax = opts["-s"] ? `s ${opts['s']} : ""` : ""
     const outFile = `-o ${getContractArtifactFilename(opts)(sourceFile)}`


### PR DESCRIPTION
Sets the DOCKER_DEFAULT_PLATFORM environment variable when running the _ligolang/ligo` docker image. Necessary to avoid docker warnings until the LIGO team is able to add multi-platform builds for their image.

Fixes #273 