### PR TITLE
ci: update existing github-bot comment in PRs instead of creating new ones for each commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,6 +223,7 @@ jobs:
               })
             }
 
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,13 +197,32 @@ jobs:
               | taq install ${{ env.SCOPE }}/${taquito.name}@0.0.0-pr-${{ github.event.number }}-${git_short_sha}|
               | taq install ${{ env.SCOPE }}/${flextesa.name}@0.0.0-pr-${{ github.event.number }}-${git_short_sha}|
             `;
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
+
+
+            const {data: comments} = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
+              issue_number: context.issue.number,
             })
+
+            const botComment = comments.find(comment => comment.user.id === 41898282)                                                                       
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              })
+            }
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,6 @@ jobs:
               })
             }
 
-
   release:
     name: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `pr-comment` job in our pipelines create new comments for each commit we push to an existing PR. This creates a lot of noise when trying to review comments left on a PR and it also fills up email inbox with a lot of redundant emails.

This PR tweaks the job to update the existing comment left by the `github-action` bot instead of creating new ones.

## Test Plan

New commits to this PR are updating the `github-action` bot comment instead of creating new comments 