### PR TITLE
Revert to direct GA properties

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 ---
+
 <!-- 
 content-type: getting started
 audience: crypto literate readers and developers looking to USE Taqueria (rather than build on it)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,7 +16,14 @@ const config = {
 	favicon: "/img/favicon.ico",
 	organizationName: "ecadlabs", // Usually your GitHub org/user name.
 	projectName: "taqueria", // Usually your repo name.
-
+	plugins: [
+		[
+		  require.resolve('docusaurus-gtm-plugin'),
+		  {
+			id: 'GTM-N6G3QD5', // GTM Container ID
+		  }
+		]
+	  ],
 	presets: [
 		[
 			"@docusaurus/preset-classic",
@@ -45,10 +52,6 @@ const config = {
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({
-			gtag: {
-				trackingID: "GTM-N6G3QD5",
-				anonymizeIP: true,
-			},
 			colorMode: {
 				defaultMode: "light",
 				disableSwitch: true,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,19 +16,11 @@ const config = {
 	favicon: "/img/favicon.ico",
 	organizationName: "ecadlabs", // Usually your GitHub org/user name.
 	projectName: "taqueria", // Usually your repo name.
-	plugins: [
-		[
-		  require.resolve('docusaurus-gtm-plugin'),
-		  {
-			id: 'GTM-N6G3QD5', // GTM Container ID
-		  }
-		]
-	  ],
 	presets: [
 		[
 			"@docusaurus/preset-classic",
 			/** @type {import('@docusaurus/preset-classic').Options} */
-
+				
 			({
 				docs: {
 					path: "docs",
@@ -52,6 +44,10 @@ const config = {
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({
+			gtag: {
+				trackingID: "303602454",
+				anonymizeIP: true,
+			},
 			colorMode: {
 				defaultMode: "light",
 				disableSwitch: true,

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
+    "docusaurus-gtm-plugin": "^0.0.2",
     "file-loader": "^6.2.0",
     "html-react-parser": "^1.4.5",
     "prism-react-renderer": "^1.2.1",


### PR DESCRIPTION
There is currently an unfixed bug with the docusaurus-gtg-plugin [details here](https://github.com/facebook/docusaurus/issues/2407) which prevents GTM from receiving events. This means technically there is no way to make Docusaurus GDPR compliant (requires gtag.js library) until this is fixed

In the meantime, I have reverted to referencing the GA4/UA compound property via the classic analytics.js lib

