### PR TITLE
Fixed type definition for Future

### DIFF
--- a/taqueria-utils/taqueria-utils-types.ts
+++ b/taqueria-utils/taqueria-utils-types.ts
@@ -55,7 +55,7 @@ export class SanitizedAbsPath {
     }
 }
 
-export type Future<L,R> = unknown
+export type Future<L,R> = ReturnType<typeof attemptP>
 
 export type reject = (_err:TaqError|Error) => void
 


### PR DESCRIPTION
The Future<L,R> type definition was aliased to unknown. I think this was something that got committed by mistake, as it should have been an alias to the type provided from the fluture library itself.