### PR TITLE
Updating GitHub footer links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -150,7 +150,7 @@ const config = {
 							},
 							{
 								label: "GitHub",
-								to: "https://github.com/ecadlabs/taqueria",
+								to: "https://github.com/ecadlabs/taqueria/discussions",
 							},
 						],
 					},

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -163,7 +163,7 @@ const config = {
 							},
 							{
 								label: "Roadmap",
-								to: "https://github.com/ecadlabs/taqueria/milestones?direction=asc&sort=due_date&state=open",
+								to: "https://taqueria.io/docs/roadmap",
 							},
 						],
 					},

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -163,7 +163,7 @@ const config = {
 							},
 							{
 								label: "Roadmap",
-								to: "https://taqueria.io/docs/roadmap",
+								to: "/docs/roadmap",
 							},
 						],
 					},


### PR DESCRIPTION
Updated taqueria.io footer links for:

- Github discussions
- Roadmap

Closes #343 