### PR TITLE
Update install CTA link

### DIFF
--- a/website/src/components/Hero/Hero.js
+++ b/website/src/components/Hero/Hero.js
@@ -20,7 +20,7 @@ const FeatureList = [
 		),
 		link: {
 			title: "Try the Beta",
-			url: "/docs/intro",
+			url: "/docs/getting-started/installation",
 		},
 
 		features: [


### PR DESCRIPTION
This PR changes the target of the "Try the Beta" CTA button to target the installation guide