### PR TITLE
updated help contents for new scaffolding entries and message indenting

### DIFF
--- a/tests/e2e/data/help-contents.ts
+++ b/tests/e2e/data/help-contents.ts
@@ -1,7 +1,9 @@
 export const helpContentsNoProject: string = `taq [command]
 
 Commands:
-  taq init [projectDir]  Initialize a new project
+  taq init [projectDir]                  Initialize a new project
+  taq scaffold [scaffoldUrl] [scaffoldP  Generate a new project using a pre
+  rojectDir]                             -configured scaffold
 
 Options:
       --version     Show version number                           [boolean]
@@ -17,9 +19,11 @@ Your config.json file is invalid
 export const helpContentsForProject: string = `taq <command>
 
 Commands:
-  taq init [projectDir]       Initialize a new project
-  taq install <pluginName>    Install a plugin
-  taq uninstall <pluginName>  Uninstall a plugin
+  taq init [projectDir]                  Initialize a new project
+  taq scaffold [scaffoldUrl] [scaffoldP  Generate a new project using a pre
+  rojectDir]                             -configured scaffold
+  taq install <pluginName>               Install a plugin
+  taq uninstall <pluginName>             Uninstall a plugin
 
 Options:
       --version     Show version number                           [boolean]
@@ -34,11 +38,13 @@ Taqueria is currently in BETA. You've been warned. :)
 export const helpContentsLigo: string = `taq <command>
 
 Commands:
-  taq init [projectDir]       Initialize a new project
-  taq install <pluginName>    Install a plugin
-  taq uninstall <pluginName>  Uninstall a plugin
-  taq compile [sourceFile]    Compile a smart contract written in a Ligo sy
-                              ntax to Michelson code
+  taq init [projectDir]                  Initialize a new project
+  taq scaffold [scaffoldUrl] [scaffoldP  Generate a new project using a pre
+  rojectDir]                             -configured scaffold
+  taq install <pluginName>               Install a plugin
+  taq uninstall <pluginName>             Uninstall a plugin
+  taq compile [sourceFile]               Compile a smart contract written i
+                                         n a Ligo syntax to Michelson code
                                                  [aliases: c, compile-ligo]
 
 Options:
@@ -54,13 +60,15 @@ Taqueria is currently in BETA. You've been warned. :)
 export const helpContentsSmartpy: string = `taq <command>
 
 Commands:
-  taq init [projectDir]       Initialize a new project
-  taq install <pluginName>    Install a plugin
-  taq uninstall <pluginName>  Uninstall a plugin
-  taq compile [sourceFile]    Compile a smart contract written in a SmartPy
-                               syntax to Michelson code
-                                              [aliases: c, compile-smartpy]
-  taq teapot                  Have a cup of tea           [aliases: t, tea]
+  taq init [projectDir]                  Initialize a new project
+  taq scaffold [scaffoldUrl] [scaffoldP  Generate a new project using a pre
+  rojectDir]                             -configured scaffold
+  taq install <pluginName>               Install a plugin
+  taq uninstall <pluginName>             Uninstall a plugin
+  taq compile [sourceFile]               Compile a smart contract written i
+                                         n a SmartPy syntax to Michelson co
+                                         de   [aliases: c, compile-smartpy]
+  taq teapot                             Have a cup of tea[aliases: t, tea]
 
 Options:
       --version     Show version number                           [boolean]
@@ -75,12 +83,14 @@ Taqueria is currently in BETA. You've been warned. :)
 export const helpContentsLigoSmartpy: string = `taq <command>
 
 Commands:
-  taq init [projectDir]       Initialize a new project
-  taq install <pluginName>    Install a plugin
-  taq uninstall <pluginName>  Uninstall a plugin
-  taq compile                 Provided by more than one plugin. The option
-                              --plugin is required.
-  taq teapot                  Have a cup of tea           [aliases: t, tea]
+  taq init [projectDir]                  Initialize a new project
+  taq scaffold [scaffoldUrl] [scaffoldP  Generate a new project using a pre
+  rojectDir]                             -configured scaffold
+  taq install <pluginName>               Install a plugin
+  taq uninstall <pluginName>             Uninstall a plugin
+  taq compile                            Provided by more than one plugin.
+                                         The option --plugin is required.
+  taq teapot                             Have a cup of tea[aliases: t, tea]
 
 Options:
       --version     Show version number                           [boolean]
@@ -95,11 +105,14 @@ Taqueria is currently in BETA. You've been warned. :)
 export const helpContentsTaquito: string = `taq <command>
 
 Commands:
-  taq init [projectDir]       Initialize a new project
-  taq install <pluginName>    Install a plugin
-  taq uninstall <pluginName>  Uninstall a plugin
-  taq deploy [contract]       Deploy a smart contract to a particular envir
-                              onment                   [aliases: originate]
+  taq init [projectDir]                  Initialize a new project
+  taq scaffold [scaffoldUrl] [scaffoldP  Generate a new project using a pre
+  rojectDir]                             -configured scaffold
+  taq install <pluginName>               Install a plugin
+  taq uninstall <pluginName>             Uninstall a plugin
+  taq deploy [contract]                  Deploy a smart contract to a parti
+                                         cular environment
+                                                       [aliases: originate]
 
 Options:
       --version     Show version number                           [boolean]
@@ -114,14 +127,17 @@ Taqueria is currently in BETA. You've been warned. :)
 export const helpContentsFlextesa: string = `taq <command>
 
 Commands:
-  taq init [projectDir]            Initialize a new project
-  taq install <pluginName>         Install a plugin
-  taq uninstall <pluginName>       Uninstall a plugin
-  taq start sandbox [sandboxName]  Starts a flextesa sandbox
+  taq init [projectDir]                  Initialize a new project
+  taq scaffold [scaffoldUrl] [scaffoldP  Generate a new project using a pre
+  rojectDir]                             -configured scaffold
+  taq install <pluginName>               Install a plugin
+  taq uninstall <pluginName>             Uninstall a plugin
+  taq start sandbox [sandboxName]        Starts a flextesa sandbox
                                                            [aliases: start]
-  taq stop sandbox [sandboxName]   Stops a flextesa sandbox [aliases: stop]
-  taq list accounts <sandboxName>  List the balances of all sandbox account
-                                   s
+  taq stop sandbox [sandboxName]         Stops a flextesa sandbox
+                                                            [aliases: stop]
+  taq list accounts <sandboxName>        List the balances of all sandbox a
+                                         ccounts
 
 Options:
       --version     Show version number                           [boolean]


### PR DESCRIPTION
This PR is to fix the help messaging after introducing the new scaffolding code which added the scaffolding to the taq binary. The checks didn't stop the [merge](https://github.com/ecadlabs/taqueria/pull/139) even though the e2e tests failed (https://github.com/ecadlabs/taqueria/runs/5254016122?check_suite_focus=true).