### PR TITLE
Add taqueria team as codeowners for readme.md file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,8 @@
 # Set the SRE team as code owners for all github workflows
 /.github/workflows/    @ecadlabs/sre
 
-# Add code owners for website
-/website/ @ecadlabs/taqueria 
+# Add Taqueria team as code owners for website
+/website/ @ecadlabs/taqueria
+
+# Add Taqueria team as code owners for readme.md
+/readme.md @ecadlabs/taqueria


### PR DESCRIPTION
We recently made the Taqueria team code owners of the /website/ dir to speed up PR approval and merging while reducing the burden on Jev and Michael W.

In addition to the /website/ dir being owned by @ecadlabs/taqueria , I think it makes sense for the Taqueria `readme.md` file to also have the taqueria team owning it due to the similarity in development and release to the website documentation