### PR TITLE
Update Docusaurus to beta v16

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -46,17 +46,16 @@ const config = {
 						require.resolve('./src/css/tabs.scss'),
 					],
 				},
+				googleAnalytics: {
+					trackingID: "UA-93014135-3",
+					anonymizeIP: true,
+				},
 			}),
 		],
 	],
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({
-				googleAnalytics: {
-					trackingID: "UA-93014135-3",
-				  anonymizeIP: true,
-
-			},
 			colorMode: {
 				defaultMode: 'light',
 				disableSwitch: true,

--- a/website/package.json
+++ b/website/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/core": "2.0.0-beta.16",
     "@docusaurus/plugin-google-analytics": "^2.0.0-beta.16",
-    "@docusaurus/preset-classic": "2.0.0-beta.9",
+    "@docusaurus/preset-classic": "2.0.0-beta.16",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",


### PR DESCRIPTION
This PR updates docusaurus from v9 to v16 and will enable the Taqueria site to use the most recent version of the GA plugin  