### PR TITLE
Fix GA tagging issues

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,7 +6,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-	plugins: ['docusaurus-plugin-sass'],
+	plugins: ['docusaurus-plugin-sass', '@docusaurus/plugin-google-gtag'],
 	title: 'Taqueria - Developer Tooling for Tezos',
 	tagline: 'Taqueria - Developer Tooling for Tezos',
 	url: 'https://taqueria.io',
@@ -31,10 +31,6 @@ const config = {
 
 					editUrl: 'https://github.com/ecadlabs/taqueria/edit/main/website/',
 				},
-				gtag: {
-					  trackingID: '303602454',
-					  anonymizeIP: true,
-				},
 				blog: {
 					showReadingTime: true,
 					// Please change this to your repo.
@@ -56,6 +52,10 @@ const config = {
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({
+			gtag: {
+				trackingID: '303602454',
+				anonymizeIP: true,
+		  },
 			colorMode: {
 				defaultMode: 'light',
 				disableSwitch: true,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,11 +52,6 @@ const config = {
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({
-				googleAnalytics: {
-					trackingID: "UA-93014135-3",
-				  anonymizeIP: true,
-
-			},
 			colorMode: {
 				defaultMode: 'light',
 				disableSwitch: true,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,13 +8,6 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
 	plugins: [
 		'docusaurus-plugin-sass',
-		[
-			'@docusaurus/plugin-google-gtag',
-			{
-			  trackingID: '303602454',
-			  anonymizeIP: true,
-			},
-		  ],
 	],
 	title: 'Taqueria - Developer Tooling for Tezos',
 	tagline: 'Taqueria - Developer Tooling for Tezos',
@@ -60,6 +53,14 @@ const config = {
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({
+			gtag: {
+				trackingID: '303602454',
+				anonymizeIP: true,
+			  },
+			  googleAnalytics: {
+				trackingID: 'UA-93014135-3',
+				anonymizeIP: true,
+			  },
 			colorMode: {
 				defaultMode: 'light',
 				disableSwitch: true,

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -31,6 +31,10 @@ const config = {
 
 					editUrl: 'https://github.com/ecadlabs/taqueria/edit/main/website/',
 				},
+				gtag: {
+					  trackingID: '303602454',
+					  anonymizeIP: true,
+				},
 				blog: {
 					showReadingTime: true,
 					// Please change this to your repo.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,13 +6,21 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-	plugins: ['docusaurus-plugin-sass', '@docusaurus/plugin-google-gtag'],
+	plugins: [
+		'docusaurus-plugin-sass',
+		[
+			'@docusaurus/plugin-google-gtag',
+			{
+			  trackingID: '303602454',
+			  anonymizeIP: true,
+			},
+		  ],
+	],
 	title: 'Taqueria - Developer Tooling for Tezos',
 	tagline: 'Taqueria - Developer Tooling for Tezos',
 	url: 'https://taqueria.io',
 	baseUrl: '/',
-
-  onBrokenLinks: 'throw',
+    onBrokenLinks: 'throw',
 	onBrokenMarkdownLinks: 'warn',
 	favicon: '/img/favicon.ico',
 	organizationName: 'ecadlabs', // Usually your GitHub org/user name.
@@ -23,7 +31,7 @@ const config = {
 			'@docusaurus/preset-classic',
 			/** @type {import('@docusaurus/preset-classic').Options} */
 				
-			({
+			{
 				docs: {
 					path: 'docs',
 					sidebarPath: require.resolve('./sidebars.js'),
@@ -46,16 +54,12 @@ const config = {
 						require.resolve('./src/css/tabs.scss'),
 					],
 				},
-			}),
+			},
 		],
 	],
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({
-			gtag: {
-				trackingID: '303602454',
-				anonymizeIP: true,
-		  },
 			colorMode: {
 				defaultMode: 'light',
 				disableSwitch: true,

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
-    "@docusaurus/plugin-google-gtag": "^2.0.0-beta.16",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/plugin-google-gtag": "^2.0.0-beta.9",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/plugin-google-analytics": "^2.0.0-beta.9",
     "@docusaurus/plugin-google-gtag": "^2.0.0-beta.9",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
     "@mdx-js/react": "^1.6.22",

--- a/website/package.json
+++ b/website/package.json
@@ -14,8 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.16",
-    "@docusaurus/preset-classic": "2.0.0-beta.16",
+    "@docusaurus/core": "2.0.0-beta.9",
+    "@docusaurus/plugin-google-gtag": "^2.0.0-beta.16",
+    "@docusaurus/preset-classic": "2.0.0-beta.9",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/website/package.json
+++ b/website/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.9",
-    "@docusaurus/preset-classic": "2.0.0-beta.9",
+    "@docusaurus/core": "2.0.0-beta.16",
+    "@docusaurus/preset-classic": "2.0.0-beta.16",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",

--- a/website/package.json
+++ b/website/package.json
@@ -15,12 +15,10 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
-    "@docusaurus/plugin-google-analytics": "^2.0.0-beta.16",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
-    "docusaurus-gtm-plugin": "^0.0.2",
     "docusaurus-plugin-sass": "^0.2.2",
     "file-loader": "^6.2.0",
     "html-react-parser": "^1.4.5",

--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
-    "@docusaurus/plugin-google-analytics": "^2.0.0-beta.9",
-    "@docusaurus/plugin-google-gtag": "^2.0.0-beta.9",
+    "@docusaurus/plugin-google-analytics": "2.0.0-beta.9",
+    "@docusaurus/plugin-google-gtag": "2.0.0-beta.9",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^5.5.0",


### PR DESCRIPTION
This PR implements GA properties for both UA and GA4 tags

It uses downgraded versions of each plugin that are compatible with the currently installed version of docusaurus