### PR TITLE
rafactor(ci): Only run-tests job for PRs from a fork

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,6 +181,13 @@ jobs:
         with:
           deno-version: "1.18.2"
 
+      - name: download the binary from the build-binaries job and make it executable
+        run: |
+          wget ${{ needs.build-binaries.outputs.public-url-ubuntu }} -O taq
+          chmod +x taq
+          echo "$(pwd)" >> $GITHUB_PATH
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+
       - name: build binary and make executable
         env:
           TAQ_VERSION: ${{ github.ref_name }}
@@ -191,6 +198,7 @@ jobs:
           [[ $(./taq init -p ./test_project) == "Project taq'ified!" ]] 
           chmod +x taq
           echo "$(pwd)" >> $GITHUB_PATH
+        if: ${{ github.event.pull_request.head.repo.fork }}
 
       - name: install dependencies
         run: npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,9 +174,14 @@ jobs:
         with:
           deno-version: "1.18.2"
 
-      - name: get binary and make executable from previous step for tests
+      - name: build binary and make executable
+        env:
+          TAQ_VERSION: ${{ github.ref_name }}
+          DENO_DIR: "./deno"
         run: |
-          wget ${{ needs.build-binaries.outputs.public-url-ubuntu }} -O taq
+          COMMIT=`git rev-parse --short "$GITHUB_SHA"`
+          deno compile --output taq --allow-run --allow-write --allow-read --allow-env index.ts --quickstart "`cat quickstart.md`" --setBuild "$TAQ_VERSION/$COMMIT" --setVersion "$TAQ_VERSION"
+          [[ $(./taq init -p ./test_project) == "Project taq'ified!" ]] 
           chmod +x taq
           echo "$(pwd)" >> $GITHUB_PATH
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
   # This job creates boolean outputs based on path filters. These outputs can then be used as job conditions
   detect-changes:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     outputs:
       vscode: ${{ steps.filter.outputs.vscode }}
     steps:
@@ -35,7 +36,8 @@ jobs:
       contents: 'read'
       id-token: 'write'
     runs-on: ${{ matrix.os }}
-    if: github.event_name != 'release'
+    if: ${{ github.event_name != 'release' &&
+            !github.event.pull_request.head.repo.fork }}
     strategy:
       fail-fast: true
       matrix:
@@ -104,6 +106,7 @@ jobs:
           echo "::set-output name=${{ matrix.os_short }}::https://storage.googleapis.com/taqueria-artifacts/${{ steps.upload-file.outputs.uploaded }}"
 
   publish-protocol-to-npm:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/npm-publish.yml
     with:
       dir: taqueria-protocol
@@ -111,6 +114,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
 
   publish-sdk-to-npm:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs: publish-protocol-to-npm
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -119,6 +123,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
 
   publish-ligo-plugin-to-npm:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs: publish-sdk-to-npm
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -127,6 +132,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
   
   publish-smartpy-plugin-to-npm:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs: publish-sdk-to-npm
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -135,6 +141,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
 
   publish-taquito-plugin-to-npm:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs: publish-sdk-to-npm
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -143,6 +150,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
 
   publish-flextesa-plugin-to-npm:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs:
       - publish-sdk-to-npm
     uses: ./.github/workflows/npm-publish.yml
@@ -152,6 +160,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
 
   publish-contract-types-plugin-to-npm:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs: publish-sdk-to-npm
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -160,8 +169,6 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
 
   run-tests:
-    needs: 
-      - build-binaries
     runs-on: ubuntu-latest
 
     steps:
@@ -205,9 +212,10 @@ jobs:
 
   vscode-extension-workflow:
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.vscode == 'true' || 
+    if: ${{ (needs.detect-changes.outputs.vscode == 'true' || 
             github.event_name == 'release' || 
-            startsWith(github.ref, 'refs/tags/v')}}
+            startsWith(github.ref, 'refs/tags/v')) &&
+            !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/vscode-extension.yml
     secrets:
       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
@@ -219,7 +227,8 @@ jobs:
     # Without the 'always()' expression, the other conditions are not evaluated if a job is skipped or fails.
     if: ${{ always() &&
             !(contains(needs.*.result, 'failure')) && 
-            github.event_name == 'pull_request'}}
+            github.event_name == 'pull_request' &&
+            !github.event.pull_request.head.repo.fork }}
     needs: 
       - build-binaries
       - publish-protocol-to-npm
@@ -348,7 +357,8 @@ jobs:
       - publish-flextesa-plugin-to-npm
       - publish-contract-types-plugin-to-npm
       - vscode-extension-workflow
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: ${{ startsWith(github.ref, 'refs/tags/v') &&
+            !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,9 @@ jobs:
 
   run-tests:
     runs-on: ubuntu-latest
-
+    needs: 
+      - build-binaries
+    if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
We are encountering errors in our CICD when workflows are triggered from forked repositories e.g #438 . These workflows fail because of some of our jobs publish assets and require write permissions. This PR adds conditions to the workflows to only run the `run-tests` job when a PR is made from a fork. 

### Testing plan
![image](https://user-images.githubusercontent.com/29157965/157558572-0c0b19cb-64c1-4b4a-8a41-f5b0418c74a4.png)
*Only run-tests job for fork PRs*

https://github.com/ecadlabs/taqueria/actions/runs/1959955142