### PR TITLE
Force docusaurus to generate trailing slash on static site gen

### DIFF
--- a/website/docs/plugins/plugin-mock-plugin.md
+++ b/website/docs/plugins/plugin-mock-plugin.md
@@ -2,7 +2,7 @@
 title: Mock Plugin 
 ---
 
-The mock plugin is a starting point for building new plugins. You can learn more about making plugins for Taqueria [here](../taqueria-dev/making-plugins)
+The mock plugin is a starting point for building new plugins. You can learn more about making plugins for Taqueria [here](/docs/taqueria-dev/making-plugins/)
 
 The basic implementation for a plugin looks like this:
 ```js

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,6 +18,7 @@ const config = {
 	favicon: '/img/favicon.ico',
 	organizationName: 'ecadlabs', // Usually your GitHub org/user name.
 	projectName: 'taqueria', // Usually your repo name.
+	trailingSlash: true,
 
 	presets: [
 		[


### PR DESCRIPTION
I've been investigating an SEO issue on the Taqueria site where every page is getting a 308 redirect. From what I can tell, this seems to be due to Cloudflare requiring a trailing slash. There are 2 options for resolving this:
1. Changing the build of the static site to add a trailing slash to all paths
2. Change the rules in Cloudflare

This PR implements a change to the Docusaurus config that forces a trailing slash (option #1) which should solve the issue if option #1 is the solution we decide to go with