### PR TITLE
BUG FIX: Integer param names

### DIFF
--- a/taqueria-plugin-contract-types/example/contracts/example-contract-10.tz
+++ b/taqueria-plugin-contract-types/example/contracts/example-contract-10.tz
@@ -1,0 +1,7 @@
+{ 
+  parameter
+    (pair %update_token_metadata nat bytes);
+  storage
+    (nat %total_supply);
+}
+

--- a/taqueria-plugin-contract-types/example/types-file/example-contract-10.code.ts
+++ b/taqueria-plugin-contract-types/example/types-file/example-contract-10.code.ts
@@ -1,0 +1,6 @@
+
+export const ExampleContract10Code: { __type: 'ExampleContract10Code', protocol: string, code: object[] } = {
+    __type: 'ExampleContract10Code',
+    protocol: 'PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo',
+    code: JSON.parse(`[{"prim":"parameter","args":[{"prim":"pair","annots":["%update_token_metadata"],"args":[{"prim":"nat"},{"prim":"bytes"}]}]},{"prim":"storage","args":[{"prim":"nat","annots":["%total_supply"]}]}]`)
+};

--- a/taqueria-plugin-contract-types/example/types-file/example-contract-10.types.ts
+++ b/taqueria-plugin-contract-types/example/types-file/example-contract-10.types.ts
@@ -8,9 +8,8 @@ type Storage = {
 
 type Methods = {
     update_token_metadata: (
-        // FAILURE: int arg name is invalid
-        0: nat,
-        1: bytes,
+        _0: nat,
+        _1: bytes,
     ) => Promise<void>;
 };
 

--- a/taqueria-plugin-contract-types/example/types-file/example-contract-10.types.ts
+++ b/taqueria-plugin-contract-types/example/types-file/example-contract-10.types.ts
@@ -1,0 +1,26 @@
+
+import { ContractAbstractionFromContractType, WalletContractAbstractionFromContractType } from './type-utils';
+import { bytes, nat } from './type-aliases';
+
+type Storage = {
+    total_supply: nat;
+};
+
+type Methods = {
+    update_token_metadata: (
+        // FAILURE: int arg name is invalid
+        0: nat,
+        1: bytes,
+    ) => Promise<void>;
+};
+
+type MethodsObject = {
+    update_token_metadata: (params: {
+        0: nat,
+        1: bytes,
+    }) => Promise<void>;
+};
+
+type contractTypes = { methods: Methods, methodsObject: MethodsObject, storage: Storage, code: { __type: 'ExampleContract10Code', protocol: string, code: object[] } };
+export type ExampleContract10ContractType = ContractAbstractionFromContractType<contractTypes>;
+export type ExampleContract10WalletType = WalletContractAbstractionFromContractType<contractTypes>;

--- a/taqueria-plugin-contract-types/src/generator/typescript-output.ts
+++ b/taqueria-plugin-contract-types/src/generator/typescript-output.ts
@@ -118,8 +118,8 @@ ${tabs(indent)}`;
         throw new GenerateApiError(`Unknown type node`, { t });
     };
 
-    const varToCode = (t: TypedVar, i: number, indent: number): string => {
-        return `${t.name ?? i}${t.type.optional ? `?` : ``}: ${typeToCode(t.type, indent)}`;
+    const varToCode = (t: TypedVar, i: number, indent: number, numberVarNamePrefix = ''): string => {
+        return `${t.name ?? `${numberVarNamePrefix}${i}`}${t.type.optional ? `?` : ``}: ${typeToCode(t.type, indent)}`;
     };
 
     const argsToCode = (args: TypedVar[], indent: number, asObject: boolean): string => {
@@ -129,7 +129,7 @@ ${tabs(indent)}`;
         }
 
         const result = `${toIndentedItems(indent, {},
-            args.filter(x => x.name || x.type.kind !== `unit`).map((a, i) => varToCode(a, i, indent + 1) + `,`),
+            args.filter(x => x.name || x.type.kind !== `unit`).map((a, i) => varToCode(a, i, indent + 1, asObject ? '' : '_') + `,`),
         )}`;
 
         if(asObject){


### PR DESCRIPTION
Claude found a case where a tuple parameter would cause a type error:

The original ligo signature was:
```
let update_token_metadata (p, s: (token_id * bytes) * storage): storage
```

- FIX this case by adding a _prefix to the argument name. `This has no runtime difference`, since argument names have no meaning to the caller at runtime