### PR TITLE
Update robots.txt file to disallow CDN pages

### DIFF
--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,4 +1,4 @@
 User-Agent: *
-Disallow: 
+Disallow: https://taqueria.io/cdn-cgi/l/email-protection
 
 Sitemap: https://taqueria.io/sitemap.xml


### PR DESCRIPTION
This PR fixes an issue with GSC indexing the robots.txt file and disallows the email CDN page from being indexed