### PR TITLE
Fix 308 redirect issue

### DIFF
--- a/website/src/components/Features/Features.js
+++ b/website/src/components/Features/Features.js
@@ -8,7 +8,7 @@ const FeatureList = [
       "Don’t know where to start building on Tezos? Want a smarter way to integrate your tools? If so, Taqueria is for you. This flexible framework will help you to start faster and build better applications.",
     button: {
       label: "Try the Taqueria Beta",
-      link: "/docs/intro",
+      link: "/docs/intro/",
     },
     features: [
       {

--- a/website/src/components/Hero/Hero.js
+++ b/website/src/components/Hero/Hero.js
@@ -20,7 +20,7 @@ const FeatureList = [
 		),
 		link: {
 			title: "Try the Beta",
-			url: "/docs/getting-started/installation",
+			url: "/docs/getting-started/installation/",
 		},
 
 		features: [


### PR DESCRIPTION
This PR adds 2 trailing slashes to links on the landing page to fix an issue with them receiving a 308 redirect which is hampering SEO indexing and page ranking