### PR TITLE
removed sdet rule from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,3 @@
 
 # Add Taqueria team as code owners for readme.md
 /readme.md @ecadlabs/taqueria
-
-# Add SDET team as code owners for tests directory in taqueria
-/tests/ @ecadlabs/sdet 


### PR DESCRIPTION
Removing this because the sdet rule is overwriting the taqueria group rule and we want more eyes on PRs rather than less