### PR TITLE
Closes #561 add missing typechecking to sdk and flextesa manager plugin

### DIFF
--- a/taqueria-flextesa-manager/package.json
+++ b/taqueria-flextesa-manager/package.json
@@ -4,7 +4,7 @@
   "description": "Provides an interface and abstraction over a flextesa mininet",
   "main": "index.js",
   "scripts": {
-    "build-package": "npx esbuild --platform=node --bundle index.ts --outdir=.",
+    "build-package": "npx tsc -noEmit index.ts && npx esbuild --platform=node --bundle index.ts --outdir=.",
     "build-docker": "TAQ_VERSION=`taq --version` BUILD=`taq --build`; docker build . -t \"ghcr.io/ecadlabs/taqueria-flextesa:${TAQ_VERSION}-${BUILD}\"",
     "build": "npm run build-package"
   },

--- a/taqueria-protocol/taqueria-protocol-types.ts
+++ b/taqueria-protocol/taqueria-protocol-types.ts
@@ -1,9 +1,9 @@
 // TODO - using .ts is necessary for Deno. Explore how to make this
 // consumable by Deno or the TypeScript compiler without any warnings
 // or errors emited
-// @ts-ignore
+// @ts-ignore see above
 import {SanitizedAbsPath, SHA256} from '../taqueria-utils/taqueria-utils-types.ts'
-// @ts-ignore
+// @ts-ignore see above
 import {urlParse} from './url-parse.ts'
 
 type URL = ReturnType<typeof urlParse>
@@ -223,7 +223,7 @@ export interface UnvalidatedTask {
     readonly aliases?: string[]
     readonly options?: (UnvalidatedOption|Option|undefined)[],
     readonly positionals?: (UnvalidatedPositionalArg|undefined|PositionalArg)[]
-    readonly handler: "proxy" | string | string[]
+    readonly handler: TaskHandler
     readonly hidden?: boolean
     readonly example?: string
     readonly encoding?: "json" | "application/json" | "none"

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -4,6 +4,7 @@ import {join, resolve, dirname, parse} from 'path'
 import {readFile, writeFile} from 'fs/promises'
 import {get} from 'stack-trace'
 import {exec, ExecException} from 'child_process'
+// @ts-ignore interop issue. Maybe find a different library later
 import generateName from 'project-name-generator'
 import {omit} from 'rambda'
 const yargs = require('yargs') // To use esbuild with yargs, we can't use ESM: https://github.com/yargs/yargs/issues/1929
@@ -136,8 +137,10 @@ const sanitizeArgs = (parsedArgs: ParsedArgs) : Promise<SanitizedArgs> =>
             contractsDir: join(projectDir, config.contractsDir),
             testsDir: join(projectDir, config.testsDir),
             artifactsDir: join(projectDir, config.artifactsDir),
-            build: parsedArgs.setBuild ?? '',
-            version: parsedArgs.setVersion ?? '',
+            build: '',
+            setBuild: parsedArgs.setBuild ?? '',
+            version: '',
+            setVersion: parsedArgs.setVersion ?? '',
             maxConcurrency: parsedArgs.maxConcurrency ?? 10,
             debug: parsedArgs.debug ?? false,
             task: parsedArgs.task ? parsedArgs.task.trim() : ''

--- a/taqueria-sdk/package.json
+++ b/taqueria-sdk/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npx esbuild --bundle index.ts --outfile=index.js --minify --platform=node --sourcemap",
+    "build": "npx tsc -noEmit index.ts && npx esbuild --bundle index.ts --outfile=index.js --minify --platform=node --sourcemap",
     "gen-schema": "npx ts-node schema-generator.ts"
   },
   "keywords": [

--- a/taqueria-sdk/types.ts
+++ b/taqueria-sdk/types.ts
@@ -1,4 +1,4 @@
-import {PluginAction, Scaffold, Hook, Sandbox as theSandbox, Network, Attributes as theAttributes, Task, UnvalidatedSandbox, UnvalidatedHook, UnvalidatedOption, UnvalidatedScaffold, UnvalidatedNetwork, EconomicalProtocol as theProtocol, UnvalidatedPositionalArg, OptionType, Environment as anEnvironment, SandboxConfig as theSandboxConfig, NetworkConfig as theNetworkConfig, EnvironmentConfig, PluginResponse as thePluginResponse, AccountDetails as theAccountDetails} from '@taqueria/protocol/taqueria-protocol-types'
+import {PluginAction, Scaffold, Hook, Sandbox as theSandbox, Network, Attributes as theAttributes, Task, UnvalidatedSandbox, UnvalidatedHook, UnvalidatedOption, UnvalidatedScaffold, UnvalidatedNetwork, EconomicalProtocol as theProtocol, UnvalidatedPositionalArg, OptionType, Environment as anEnvironment, SandboxConfig as theSandboxConfig, NetworkConfig as theNetworkConfig, EnvironmentConfig, PluginResponse as thePluginResponse, AccountDetails as theAccountDetails, TaskHandler} from '@taqueria/protocol/taqueria-protocol-types'
 
 export type Sandbox = theSandbox
 
@@ -21,7 +21,7 @@ export interface TaskView {
     readonly aliases: string[]
     readonly options: UnvalidatedOption[]
     readonly positionals: UnvalidatedPositionalArg[]
-    readonly handler: "proxy" | string | string[]
+    readonly handler: TaskHandler
     readonly encoding: "json" | "application/json" | "none"
 }
 

--- a/taqueria-sdk/types.ts
+++ b/taqueria-sdk/types.ts
@@ -1,4 +1,4 @@
-import {PluginAction, Scaffold, Hook, Sandbox as theSandbox, Network, Attributes as theAttributes, Task, UnvalidatedSandbox, UnvalidatedHook, UnvalidatedOption, UnvalidatedScaffold, UnvalidatedNetwork, EconomicalProtocol as theProtocol, UnvalidatedPositionalArg, OptionType, Environment as anEnvironment, SandboxConfig as theSandboxConfig, NetworkConfig as theNetworkConfig, EnvironmentConfig, PluginResponse as thePluginResponse, AccountDetails as theAccountDetails, TaskHandler} from '@taqueria/protocol/taqueria-protocol-types'
+import {PluginAction, TaskHandler, Scaffold, Hook, Sandbox as theSandbox, Network, Attributes as theAttributes, Task, UnvalidatedSandbox, UnvalidatedHook, UnvalidatedOption, UnvalidatedScaffold, UnvalidatedNetwork, EconomicalProtocol as theProtocol, UnvalidatedPositionalArg, OptionType, Environment as anEnvironment, SandboxConfig as theSandboxConfig, NetworkConfig as theNetworkConfig, EnvironmentConfig, PluginResponse as thePluginResponse, AccountDetails as theAccountDetails} from '@taqueria/protocol/taqueria-protocol-types'
 
 export type Sandbox = theSandbox
 


### PR DESCRIPTION
It's initially meant to fix a code style, but later discovered that type checking was missing in the sdk and flextesa manager plugin workspaces.

Closes #561