### PR TITLE
Fixes #578, e2e tests not running locally

### DIFF
--- a/npm.ts
+++ b/npm.ts
@@ -41,7 +41,10 @@ export const requireNPM = (projectDir: SanitizedAbsPath, i18n: i18n) : Future<Ta
 )
 
 export const getPluginPackageJson = (pluginNameOrPath: string, projectDir: SanitizedAbsPath) => pipe(
-    readJsonFile(SanitizedAbsPath.create(pluginNameOrPath, projectDir).join('package.json').value),
+    /^\//.test(pluginNameOrPath) 
+        ? SanitizedAbsPath.create(pluginNameOrPath)
+        : SanitizedAbsPath.create(pluginNameOrPath, projectDir),
+    pluginPath => readJsonFile(pluginPath.join('package.json').value),
     chainRej (() => readJsonFile(projectDir.join("node_modules", pluginNameOrPath, "package.json").value)),
     map(value => value as Manifest)
 )


### PR DESCRIPTION
NOTE: This shouldn't resolve the scaffolding e2e tests.

See https://github.com/ecadlabs/taqueria/issues/578

I've worked around the issue by running `npm init -y` outside of the workspace, and then moving the test project directory back into the workspace. This is necessary as our test cases make assumptions that the directory is relative to the tests/e2e directory.