### PR TITLE
As a Taqueria dev, I want my code to be automatically tested only on pushing branch to origin, so that the codebase on GitHub is healthy but it doesn't force me to run tests on all my local commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run test:unit -w tests
-
 ## Process documentation files and add modified files to the git commit
 echo "Processing documentation files..."
 npx ts-node ./parse-readme-template.ts

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run test:unit -w tests


### PR DESCRIPTION
~I've opened this PR as I find running tests on commit as an antipattern.
Tests should be run on every commit but on CI, not on a local machine.
Developers should run the test locally whenever they want.~

~Running tests on commit makes the whole commit experience super sluggish.
We now have only 1 unit tests, I can't imagine waiting 30 seconds or a few minutes on every commit.
My workflow is to commit small changes frequently, and this prevents me from doing this.~

~We should only do quick checks like ensuring the codebase is well formatted (with the help of dPrint PR #695).
I used to think that pre-commit hook is a good place for linting the code, but it also makes the commit slower and irritating for a developer.
If we do the `-fix` version, it may commit some unwanted changes, like removing comments or changing variable names.
If it warns and stop commit, it's super annoying.~
