### PR TITLE
Fixed issue with SDK not compiling due to x32 being used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,10 @@ tests/coverage
 /taqueria-sdk/index.js.map
 /taqueria-sdk/types.js
 /taqueria-sdk/types.js.map
+/taqueria-sdk/index.esm.js
+/taqueria-sdk/index.esm.js.map
+/taqueria-sdk/types.esm.js
+/taqueria-sdk/types.esm.js.map
 /taqueria-plugin-smartpy/index.js
 /taqueria-plugin-smartpy/index.js.map
 /taqueria-plugin-ligo/index.js

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -60,6 +60,7 @@ export const getArch = () : LikeAPromise<string, TaqError> => {
     switch(process.arch) {
         case 'arm64':
             return Promise.resolve('linux/arm64/v8')
+        // @ts-ignore: x32 is valid for some versions of NodeJS
         case 'x32':
         case 'x64':
             return Promise.resolve('linux/amd64')

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -363,7 +363,7 @@ const inferPluginName = (stack: ReturnType<typeof get>): () => string => {
     // To do so, we need to get the directory for the plugin from the call stack
     const pluginManifest = stack.reduce(
         (retval: null|string, callsite) => {
-            const callerFile = callsite.getFileName()
+            const callerFile = callsite.getFileName()?.replace(/^file:\/\//, '')
             return retval || (
                 callerFile.includes('taqueria-sdk') || 
                 callerFile.includes('taqueria-node-sdk') ||

--- a/taqueria-sdk/package.json
+++ b/taqueria-sdk/package.json
@@ -12,9 +12,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npx tsc -noEmit && npm run build-cjs && npm run build-esm-index && npm run build-esm-types",
-    "build-cjs": "npx esbuild --bundle index.ts types.ts --outdir=. --minify --platform=node --sourcemap",
-    "build-esm-index": "npx esbuild --bundle index.ts --outfile=index.esm.js --minify --platform=node --format=esm --sourcemap",
-    "build-esm-types": "npx esbuild --bundle types.ts --outfile=types.esm.js --minify --platform=node --format=esm --sourcemap"
+    "build-cjs": "npx esbuild --bundle index.ts types.ts --outdir=. --platform=node --sourcemap",
+    "build-esm-index": "npx esbuild --bundle index.ts --outfile=index.esm.js --platform=node --format=esm --sourcemap",
+    "build-esm-types": "npx esbuild --bundle types.ts --outfile=types.esm.js --platform=node --format=esm --sourcemap"
   },
   "keywords": [
     "taqueria",

--- a/taqueria-sdk/package.json
+++ b/taqueria-sdk/package.json
@@ -4,15 +4,17 @@
   "description": "A TypeScript SDK for NodeJS used for Taqueria plugin development.",
   "main": "./index.js",
   "source": "./index.ts",
-  "targets": {
-    "main": {
-      "context": "node",
-      "isLibrary": true
-    }
+  "module": "./index.esm.js",
+  "exports": {
+    ".": "./index.js",
+    "./types": "./types.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npx tsc -noEmit && npx esbuild --bundle index.ts types.ts --outdir=. --minify --platform=node --sourcemap"
+    "build": "npx tsc -noEmit && npm run build-cjs && npm run build-esm-index && npm run build-esm-types",
+    "build-cjs": "npx esbuild --bundle index.ts types.ts --outdir=. --minify --platform=node --sourcemap",
+    "build-esm-index": "npx esbuild --bundle index.ts --outfile=index.esm.js --minify --platform=node --format=esm --sourcemap",
+    "build-esm-types": "npx esbuild --bundle types.ts --outfile=types.esm.js --minify --platform=node --format=esm --sourcemap"
   },
   "keywords": [
     "taqueria",

--- a/taqueria-sdk/types.ts
+++ b/taqueria-sdk/types.ts
@@ -13,6 +13,7 @@ import * as NetworkConfig from "@taqueria/protocol/NetworkConfig"
 import * as Environment from "@taqueria/protocol/Environment"
 import * as PersistentState from "@taqueria/protocol/PersistentState"
 import * as TaqError from "@taqueria/protocol/TaqError"
+import * as SanitizedAbsPath from "@taqueria/protocol/SanitizedAbsPath"
 import type {i18n} from "@taqueria/protocol/i18n"
 import { P } from 'ts-pattern'
 export type PluginResponse = Protocol.PluginResponse
@@ -30,7 +31,8 @@ export {
     NetworkConfig,
     Environment,
     PersistentState,
-    TaqError
+    TaqError,
+    SanitizedAbsPath
 }
 
 export interface LikeAPromise<Success, TaqError> extends Promise<Success> {


### PR DESCRIPTION
This was cherry-picked from a change I made in a different branch for the jest plugin. It also includes adding an ESM module as a build target.