### PR TITLE
chore: removed release dependency on the vscode workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -502,7 +502,7 @@ jobs:
       - publish-tezos-client-plugin-to-npm
       - publish-state-plugin-to-npm
       - publish-jest-plugin-to-npm
-      - vscode-extension-workflow
+      # - vscode-extension-workflow
     if: ${{ startsWith(github.ref, 'refs/tags/v') &&
             !github.event.pull_request.head.repo.fork }}
     steps:


### PR DESCRIPTION
Removing the `vscode-extension-workflow` dependency for the release