### PR TITLE
fix: fix the failing assertion when the test project is initialized

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,11 @@ jobs:
           BUILD=`git rev-parse --short "$GITHUB_SHA"`
           TAQ_VERSION="${TAQ_VERSION/\//-}"
           deno compile -o taq --allow-run --allow-write --allow-read --allow-env --import-map ./import_map.json --no-prompt --target $DENO_TARGET index.ts --quickstart "`cat quickstart.md`" --setBuild "$BUILD" --setVersion "$TAQ_VERSION"
-          [[ $(./"${{ matrix.taqueria_bin }}" init -p ./test_project) == "Project taq'ified!" ]] 
+          ./"${{ matrix.taqueria_bin }}" init -p ./test_project
+          if [ ! -f ./test_project/.taq/config.json ]; then
+            echo "Project not initialized"
+            exit 1
+          fi
           mv "${{ matrix.taqueria_bin }}" "taq.${{ matrix.deno_target }}"
 
       - name: Authenticate with GCP


### PR DESCRIPTION
In the `main.yml` workflow there is an assertion made after the binaries are compiled:

```shell
[[ $(./"${{ matrix.taqueria_bin }}" init -p ./test_project) == "Project taq'ified!" ]] 
```
The assertion no longer works on the windows runner. This PR aims to fix that by making a new assertion that checks if the `config.json` file exists in the `test_project/.taq/` directory