### PR TITLE
Refactor scaffold task to use setup script

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -415,7 +415,7 @@ const scaffoldProject = (i18n: i18n.t) =>
 			await eager(rm(gitDir));
 			log('    ✓ Remove Git directory');
 
-			await eager(exec('npm install 2>&1 > /dev/null', {}, false, destDir));
+			await eager(exec('npm run setup 2>&1 > /dev/null', {}, false, destDir));
 			log('    ✓ Install plugins');
 
 			await eager(exec('taq init 2>&1 > /dev/null', {}, false, destDir));


### PR DESCRIPTION
This PR makes a tiny change to the scaffold task so that it will run `npm run setup` instead of `npm i`. This is required for Rick's scaffolds to work in VS code properly and will provide more flexibility for upcoming refactors to the project structure