### PR TITLE
Display separate artifacts tree view with originate button

### DIFF
--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -142,6 +142,11 @@
 					"when": "@taqueria-state/is-taq-cli-reachable && !@taqueria-state/enable-init-scaffold"
 				},
 				{
+					"id": "taqueria-artifacts",
+					"name": "Artifacts",
+					"contextualTitle": "Artifacts"
+				},
+				{
 					"id": "taqueria-environments",
 					"name": "Environments",
 					"contextualTitle": "Taqueria: Environments",
@@ -379,7 +384,7 @@
 				},
 				{
 					"command": "taqueria.originate",
-					"when": "view == taqueria-environments || view == taqueria-contracts",
+					"when": "view == taqueria-environments || view == taqueria-artifacts",
 					"group": "inline"
 				},
 				{

--- a/taqueria-vscode-extension/src/lib/gui/ArtifactsDataProvider.ts
+++ b/taqueria-vscode-extension/src/lib/gui/ArtifactsDataProvider.ts
@@ -1,0 +1,50 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { HasFileName, HasRefresh, VsCodeHelper } from '../helpers';
+
+export class ArtifactsDataProvider implements vscode.TreeDataProvider<ArtifactTreeItem>, HasRefresh {
+	constructor(
+		private workspaceRoot: string,
+		private helper: VsCodeHelper,
+	) {}
+
+	getTreeItem(element: ArtifactTreeItem): vscode.TreeItem {
+		return element;
+	}
+
+	async getChildren(element?: ArtifactTreeItem): Promise<ArtifactTreeItem[]> {
+		const artifacts = await vscode.workspace.findFiles('artifacts/*.*', '**/node_modules/**');
+
+		const treeItems = artifacts.map(uri =>
+			new ArtifactTreeItem(
+				path.basename(uri.path),
+				vscode.TreeItemCollapsibleState.None,
+			)
+		);
+		return treeItems;
+	}
+
+	private _onDidChangeTreeData: vscode.EventEmitter<ArtifactTreeItem | undefined | null | void> = new vscode
+		.EventEmitter<
+		ArtifactTreeItem | undefined | null | void
+	>();
+	readonly onDidChangeTreeData: vscode.Event<ArtifactTreeItem | undefined | null | void> =
+		this._onDidChangeTreeData.event;
+
+	refresh(): void {
+		this._onDidChangeTreeData.fire();
+	}
+}
+
+export class ArtifactTreeItem extends vscode.TreeItem implements HasFileName {
+	fileName: string;
+
+	constructor(
+		readonly label: string,
+		readonly collapsibleState: vscode.TreeItemCollapsibleState,
+	) {
+		super(label, collapsibleState);
+		this.tooltip = `${label}`;
+		this.fileName = label;
+	}
+}

--- a/taqueria-vscode-extension/src/lib/gui/ArtifactsDataProvider.ts
+++ b/taqueria-vscode-extension/src/lib/gui/ArtifactsDataProvider.ts
@@ -1,12 +1,14 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { HasFileName, HasRefresh, VsCodeHelper } from '../helpers';
+import { TaqueriaDataProviderBase } from './TaqueriaDataProviderBase';
 
-export class ArtifactsDataProvider implements vscode.TreeDataProvider<ArtifactTreeItem>, HasRefresh {
-	constructor(
-		private workspaceRoot: string,
-		private helper: VsCodeHelper,
-	) {}
+export class ArtifactsDataProvider extends TaqueriaDataProviderBase
+	implements vscode.TreeDataProvider<ArtifactTreeItem>, HasRefresh
+{
+	constructor(helper: VsCodeHelper) {
+		super(helper);
+	}
 
 	getTreeItem(element: ArtifactTreeItem): vscode.TreeItem {
 		return element;

--- a/taqueria-vscode-extension/src/lib/helpers.ts
+++ b/taqueria-vscode-extension/src/lib/helpers.ts
@@ -6,7 +6,7 @@ import { stat } from 'fs/promises';
 import os from 'os';
 import path, { join } from 'path';
 import * as api from 'vscode';
-import { ArtifactsDataProvider } from './gui/ArtifactsDataProvider';
+import { ArtifactsDataProvider, ArtifactTreeItem } from './gui/ArtifactsDataProvider';
 import { ContractTreeItem } from './gui/ContractsDataProvider';
 import { ContractsDataProvider } from './gui/ContractsDataProvider';
 import { EnvironmentTreeItem } from './gui/EnvironmentsDataProvider';
@@ -507,12 +507,12 @@ export class VsCodeHelper {
 		});
 	}
 
-	getContractFileName(fileName: string) {
+	getArtifactFileNameFromContract(fileName: string) {
 		return fileName.replace(/\.[^/.]+$/, '') + '.tz';
 	}
 
 	async exposeOriginateTask() {
-		this.registerCommand(Commands.originate, async (arg?: ContractTreeItem | EnvironmentTreeItem | undefined) => {
+		this.registerCommand(Commands.originate, async (arg?: ArtifactTreeItem | EnvironmentTreeItem | undefined) => {
 			const projectDir = await this.getFolderForTasksOnTaqifiedFolders('install');
 			if (projectDir === undefined) {
 				return;
@@ -523,8 +523,8 @@ export class VsCodeHelper {
 				if (arg instanceof EnvironmentTreeItem) {
 					environmentName = arg.label;
 				}
-				if (arg instanceof ContractTreeItem) {
-					fileName = this.getContractFileName(arg.fileName);
+				if (arg instanceof ArtifactTreeItem) {
+					fileName = arg.fileName;
 				}
 			}
 			if (!environmentName) {
@@ -637,10 +637,10 @@ export class VsCodeHelper {
 			let sandboxName: string | undefined = undefined;
 			if (arg) {
 				if (arg instanceof SandboxTreeItem) {
-					sandboxName = (arg as SandboxTreeItem).label;
+					sandboxName = arg.label;
 				}
 				if (arg instanceof ContractTreeItem) {
-					fileName = this.getContractFileName((arg as ContractTreeItem).fileName);
+					fileName = this.getArtifactFileNameFromContract(arg.fileName);
 				}
 			}
 			if (!sandboxName) {

--- a/taqueria-vscode-extension/src/lib/helpers.ts
+++ b/taqueria-vscode-extension/src/lib/helpers.ts
@@ -1035,6 +1035,7 @@ export class VsCodeHelper {
 					stateWatcher,
 					contractsFolderWatcher,
 					contractsWatcher,
+					artifactsFolderWatcher,
 					artifactsWatcher,
 					testsWatcher,
 				];

--- a/taqueria-vscode-extension/src/lib/helpers.ts
+++ b/taqueria-vscode-extension/src/lib/helpers.ts
@@ -1024,13 +1024,20 @@ export class VsCodeHelper {
 				artifactsWatcher.onDidChange(_ => this.artifactsDataProvider?.refresh());
 				artifactsWatcher.onDidCreate(_ => this.artifactsDataProvider?.refresh());
 				artifactsWatcher.onDidDelete(_ => this.artifactsDataProvider?.refresh());
-				
+
 				testsWatcher.onDidChange(_ => this.testDataProvider?.refresh());
 				testsWatcher.onDidCreate(_ => this.testDataProvider?.refresh());
 				testsWatcher.onDidDelete(_ => this.testDataProvider?.refresh());
 
-				return [folderWatcher, configWatcher, stateWatcher, contractsFolderWatcher, contractsWatcher, artifactsWatcher, testsWatcher];
-
+				return [
+					folderWatcher,
+					configWatcher,
+					stateWatcher,
+					contractsFolderWatcher,
+					contractsWatcher,
+					artifactsWatcher,
+					testsWatcher,
+				];
 			} catch (error: unknown) {
 				throw {
 					kind: 'E_UnknownError',
@@ -1062,7 +1069,7 @@ export class VsCodeHelper {
 		);
 		this.artifactsDataProvider = this.registerDataProvider(
 			'taqueria-artifacts',
-			new ArtifactsDataProvider(workspaceFolder, this),
+			new ArtifactsDataProvider(this),
 		);
 		this.registerDataProvider('taqueria-scaffold', new ScaffoldsDataProvider(this));
 	}


### PR DESCRIPTION
Implements #1019

> Currently, we have one TreeView that shows contracts.
But some of the commands that should be run on artifacts are enabled on that view.
So if a user runs an artifact command (like originate) on a contract, the TVsCE has a logic that decides which artifact to run this command on.
This logic is super simple now, and fails in many cases: it replaces the file extension of the contract with .tz to get the artifact file name. This does not work for smartpy.
So a better option would be to have a better distinction of contracts and artifacts. So the user can run the right commands on each.

<img width="488" alt="image" src="https://user-images.githubusercontent.com/10618781/181757696-39b12014-749c-4428-89ac-f0709cc30ded.png">
