### PR TITLE
Fix missing `when` clause for Artifacts view

### DIFF
--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -144,7 +144,8 @@
 				{
 					"id": "taqueria-artifacts",
 					"name": "Artifacts",
-					"contextualTitle": "Artifacts"
+					"contextualTitle": "Taqueria: Artifacts",
+					"when": "@taqueria-state/is-taq-cli-reachable && !@taqueria-state/enable-init-scaffold"
 				},
 				{
 					"id": "taqueria-environments",


### PR DESCRIPTION
Fixes issue with Artifacts view being displayed all the time:

![image](https://user-images.githubusercontent.com/10618781/183110627-f07c5766-d503-452c-a4f8-0814ba04b620.png)
