### PR TITLE
chore: add workflow to delete old workflows

### DIFF
--- a/.github/workflows/workflow-pruning.yml
+++ b/.github/workflows/workflow-pruning.yml
@@ -1,0 +1,59 @@
+name: Prune workflow runs
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days to keep'
+        required: true
+        default: 30
+      minimum_runs:
+        description: 'The minimum runs to keep for each workflow.'
+        required: true
+        default: 1
+      delete_workflow_pattern:
+        description: 'The name or filename of the workflow. if not set then it will target all workflows.'
+        required: false
+      delete_workflow_by_state_pattern:
+        description: 'Remove workflow by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually'
+        required: true
+        default: "All"
+        type: choice
+        options:
+          - "All"
+          - active
+          - deleted
+          - disabled_inactivity
+          - disabled_manually
+      dry_run:
+        description: 'Only log actions, do not perform any delete operations.'
+        required: false
+
+jobs:
+  scheduled-delete-old-workflow-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 30
+          keep_minimum_runs: 1
+        if: ${{ github.event_name == 'schedule' }}
+
+  manual-delete-old-workflow-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ github.event.inputs.days }}
+          keep_minimum_runs: ${{ github.event.inputs.minimum_runs }}
+          delete_workflow_pattern: ${{ github.event.inputs.delete_workflow_pattern }}
+          delete_workflow_by_state_pattern: ${{ github.event.inputs.delete_workflow_by_state_pattern }}
+          dry_run: ${{ github.event.inputs.dry_run }}
+        if: ${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
This change will add a workflow that will delete old workflow runs that are no longer required. In the past we have had incidents where old workflow runs can cause confusion when trying to debug a specific issue. One such incident happened previously during a release https://ecadlabs.slack.com/archives/C036G3SVA4Q/p1656525987109809.

Here is an example of some workflows that no longer exist
![image](https://user-images.githubusercontent.com/29157965/184207695-e6640d62-c776-4929-ab0d-66b922659b7f.png)

There were a lot more than those listed in the screenshot that were manually deleted. 

Unfortunately we can not see this workflow in action until it is merged into main. I tested it out successfully in the `taqueria-github-action` repo if anyone wants to see how it works before merge.

https://github.com/ecadlabs/taqueria-github-action/runs/7774502009?check_suite_focus=true