### PR TITLE
🏗️  ➾Re-enable Contract Types Plugin Publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,7 +221,7 @@ jobs:
 
   publish-contract-types-plugin-to-npm:
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    # needs: publish-sdk-to-npm
+    needs: publish-sdk-to-npm
     uses: ./.github/workflows/npm-publish.yml
     with:
       dir: taqueria-plugin-contract-types

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,14 +219,14 @@ jobs:
     secrets:
       NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
 
-  # publish-contract-types-plugin-to-npm:
-  #   if: ${{ !github.event.pull_request.head.repo.fork }}
-  #   # needs: publish-sdk-to-npm
-  #   uses: ./.github/workflows/npm-publish.yml
-  #   with:
-  #     dir: taqueria-plugin-contract-types
-  #   secrets:
-  #     NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
+  publish-contract-types-plugin-to-npm:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    # needs: publish-sdk-to-npm
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      dir: taqueria-plugin-contract-types
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPMJS_PAT }}
 
   publish-ipfs-pinata-plugin-to-npm:
     if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -515,7 +515,7 @@ jobs:
       - publish-smartpy-plugin-to-npm
       - publish-taquito-plugin-to-npm
       - publish-flextesa-plugin-to-npm
-      # - publish-contract-types-plugin-to-npm
+      - publish-contract-types-plugin-to-npm
       - publish-archetype-plugin-to-npm
       - publish-tezos-client-plugin-to-npm
       - publish-state-plugin-to-npm


### PR DESCRIPTION
## 🪂 Pre-Merge Checklist

N/A

----------------------------------------------------------------------------------------------------------------------------

## 🪁 Description

The publish step for the Contract Types plugin has been disabled since the 0.10.0 release of Taqueria. As such, the plugin is now 2 versions behind the rest of Taqueria and has caused a user-reported bug. This PR re-enables the skipped steps in `main.yml` 

> Note: I have manually published v0.12.0 of the plugin  

## 🎢 Test Plan

N/A

----------------------------------------------------------------------------------------------------------------------------

### 🛸 Type of Change

- [x] 🐟 Minor change (non-breaking change of very limited scope)
- [ ] 🦑 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🌊 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🐳 Major refactor (breaking changes and significant impact to the codebase)

----------------------------------------------------------------------------------------------------------------------------
