### PR TITLE
🏗️ PR ➾ LIGO improvements part 1 (compile storage and parameter)

### DIFF
--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -163,24 +163,24 @@ const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFi
 	const contractCompileResult = await compileContract(parsedArgs, sourceFile);
 	if (contractCompileResult.artifact === COMPILE_ERR_MSG) return [contractCompileResult];
 
-	const storagesFilename = `${removeExt(sourceFile)}.storages${extractExt(sourceFile)}`;
-	const parametersFilename = `${removeExt(sourceFile)}.parameters${extractExt(sourceFile)}`;
-	const storageFilePath = `${parsedArgs.config.contractsDir}/${storagesFilename}`;
-	const parameterFilePath = `${parsedArgs.config.contractsDir}/${parametersFilename}`;
+	const storagesFile = `${removeExt(sourceFile)}.storages${extractExt(sourceFile)}`;
+	const parametersFile = `${removeExt(sourceFile)}.parameters${extractExt(sourceFile)}`;
+	const storageFilename = getInputFilename(parsedArgs, storagesFile);
+	const parameterFilename = getInputFilename(parsedArgs, parametersFile);
 
-	const storageCompileResult = await access(storageFilePath)
-		.then(() => compileExprs(parsedArgs, storagesFilename, 'storage'))
+	const storageCompileResult = await access(storageFilename)
+		.then(() => compileExprs(parsedArgs, storagesFile, 'storage'))
 		.catch(() =>
 			sendWarn(
-				`Note: storage file associated with "${sourceFile}" can't be found. You should create a file "${storagesFilename}" and define initial storage values as a list of LIGO variable definitions. e.g. "let STORAGE_NAME: storage = LIGO_EXPR" for CameLigo`,
+				`Note: storage file associated with "${sourceFile}" can't be found. You should create a file "${storagesFile}" and define initial storage values as a list of LIGO variable definitions. e.g. "let STORAGE_NAME: storage = LIGO_EXPR" for CameLigo`,
 			)
 		);
 
-	const parameterCompileResult = await access(parameterFilePath)
-		.then(() => compileExprs(parsedArgs, parametersFilename, 'parameter'))
+	const parameterCompileResult = await access(parameterFilename)
+		.then(() => compileExprs(parsedArgs, parametersFile, 'parameter'))
 		.catch(() =>
 			sendWarn(
-				`Note: parameter file associated with "${sourceFile}" can't be found. You should create a file "${parametersFilename}" and define parameter values as a list of LIGO variable definitions. e.g. "let PARAMETER_NAME: parameter = LIGO_EXPR" for CameLigo`,
+				`Note: parameter file associated with "${sourceFile}" can't be found. You should create a file "${parametersFile}" and define parameter values as a list of LIGO variable definitions. e.g. "let PARAMETER_NAME: parameter = LIGO_EXPR" for CameLigo`,
 			)
 		);
 

--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -165,10 +165,10 @@ const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFi
 
 	const storagesFile = `${removeExt(sourceFile)}.storages${extractExt(sourceFile)}`;
 	const parametersFile = `${removeExt(sourceFile)}.parameters${extractExt(sourceFile)}`;
-	const storageFilename = getInputFilename(parsedArgs, storagesFile);
-	const parameterFilename = getInputFilename(parsedArgs, parametersFile);
+	const storagesFilename = getInputFilename(parsedArgs, storagesFile);
+	const parametersFilename = getInputFilename(parsedArgs, parametersFile);
 
-	const storageCompileResult = await access(storageFilename)
+	const storageCompileResult = await access(storagesFilename)
 		.then(() => compileExprs(parsedArgs, storagesFile, 'storage'))
 		.catch(() =>
 			sendWarn(
@@ -176,7 +176,7 @@ const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFi
 			)
 		);
 
-	const parameterCompileResult = await access(parameterFilename)
+	const parameterCompileResult = await access(parametersFilename)
 		.then(() => compileExprs(parsedArgs, parametersFile, 'parameter'))
 		.catch(() =>
 			sendWarn(

--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -157,7 +157,7 @@ const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFi
 		.then(() => compileExprs(parsedArgs, storagesFilename, 'storage'))
 		.catch(() =>
 			console.error(
-				`Note: storage file associated with ${sourceFile} can't be found. You should create a file named ${storagesFilename} in the same directory as ${sourceFile} and define initial storage values as a list of LIGO variable definitions, where the first one will be taken as the default for origination. e.g. "let STORAGE_NAME: storage = LIGO_EXPR" for mligo`,
+				`Note: storage file associated with ${sourceFile} can't be found. You should create a file named ${storagesFilename} in the same directory as ${sourceFile} and define initial storage values as a list of LIGO variable definitions. e.g. "let STORAGE_NAME: storage = LIGO_EXPR" for mligo`,
 			)
 		);
 
@@ -165,7 +165,7 @@ const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFi
 		.then(() => compileExprs(parsedArgs, parametersFilename, 'parameter'))
 		.catch(() =>
 			console.error(
-				`Note parameter file associated with ${sourceFile} can't be found. You should create a file named ${parametersFilename} in the same directory as ${sourceFile} and define parameter values as a list of LIGO variable definitions. e.g. "let PARAMETER_NAME: parameter = LIGO_EXPR" for mligo`,
+				`Note: parameter file associated with ${sourceFile} can't be found. You should create a file named ${parametersFilename} in the same directory as ${sourceFile} and define parameter values as a list of LIGO variable definitions. e.g. "let PARAMETER_NAME: parameter = LIGO_EXPR" for mligo`,
 			)
 		);
 

--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -170,19 +170,19 @@ const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFi
 
 	const storageCompileResult = await access(storagesFilename)
 		.then(() => compileExprs(parsedArgs, storagesFile, 'storage'))
-		.catch(() =>
-			sendWarn(
-				`Note: storage file associated with "${sourceFile}" can't be found. You should create a file "${storagesFile}" and define initial storage values as a list of LIGO variable definitions. e.g. "let STORAGE_NAME: storage = LIGO_EXPR" for CameLigo`,
-			)
-		);
+		.catch(() => {
+			// sendWarn(
+			// 	`Note: storage file associated with "${sourceFile}" can't be found. You should create a file "${storagesFile}" and define initial storage values as a list of LIGO variable definitions. e.g. "let STORAGE_NAME: storage = LIGO_EXPR" for CameLigo`,
+			// )
+		});
 
 	const parameterCompileResult = await access(parametersFilename)
 		.then(() => compileExprs(parsedArgs, parametersFile, 'parameter'))
-		.catch(() =>
-			sendWarn(
-				`Note: parameter file associated with "${sourceFile}" can't be found. You should create a file "${parametersFile}" and define parameter values as a list of LIGO variable definitions. e.g. "let PARAMETER_NAME: parameter = LIGO_EXPR" for CameLigo`,
-			)
-		);
+		.catch(() => {
+			// sendWarn(
+			// 	`Note: parameter file associated with "${sourceFile}" can't be found. You should create a file "${parametersFile}" and define parameter values as a list of LIGO variable definitions. e.g. "let PARAMETER_NAME: parameter = LIGO_EXPR" for CameLigo`,
+			// )
+		});
 
 	let compileResults: TableRow[] = [contractCompileResult];
 	if (storageCompileResult) compileResults = compileResults.concat(storageCompileResult);
@@ -222,7 +222,7 @@ const mergeArtifactsOutput = (sourceFile: string) =>
 		}];
 	};
 
-export const compile = (parsedArgs: Opts) => {
+export const compile = (parsedArgs: Opts): Promise<void> => {
 	const sourceFile = parsedArgs.sourceFile;
 	if (!sourceFile) return sendAsyncErr('No source file specified.');
 	let p: Promise<TableRow[]>;

--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -225,18 +225,16 @@ const mergeArtifactsOutput = (sourceFile: string) =>
 export const compile = (parsedArgs: Opts) => {
 	const sourceFile = parsedArgs.sourceFile;
 	if (!sourceFile) return sendAsyncErr('No source file specified.');
-	try {
-		if (isStoragesFile(sourceFile)) return compileExprs(parsedArgs, sourceFile, 'storage').then(sendJsonRes);
-		if (isParametersFile(sourceFile)) return compileExprs(parsedArgs, sourceFile, 'parameter').then(sendJsonRes);
-		if (isContractFile(sourceFile)) {
-			return compileContractWithStorageAndParameter(parsedArgs, sourceFile).then(sendJsonRes);
-		}
+	let p: Promise<TableRow[]>;
+	if (isStoragesFile(sourceFile)) p = compileExprs(parsedArgs, sourceFile, 'storage');
+	else if (isParametersFile(sourceFile)) p = compileExprs(parsedArgs, sourceFile, 'parameter');
+	else if (isContractFile(sourceFile)) p = compileContractWithStorageAndParameter(parsedArgs, sourceFile);
+	else {
 		return sendAsyncErr(
 			`${sourceFile} doesn't have a valid LIGO extension ('.ligo', '.religo', '.mligo' or '.jsligo')`,
 		);
-	} catch (err: any) {
-		return sendAsyncErr(err, false);
 	}
+	return p.then(sendJsonRes).catch(err => sendAsyncErr(err, false));
 };
 
 export default compile;

--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -1,50 +1,87 @@
 import { execCmd, getArch, getContracts, sendAsyncErr, sendErr, sendJsonRes } from '@taqueria/node-sdk';
 import { RequestArgs } from '@taqueria/node-sdk/types';
+import { mapOperationsToPlugins } from '@taqueria/protocol/EphemeralState';
+import { readFile, writeFile } from 'fs/promises';
 import { basename, extname, join } from 'path';
 
 interface Opts extends RequestArgs.t {
-	entrypoint?: string;
-	syntax?: string;
-	sourceFile?: string;
+	sourceFile: string;
 }
 
-const getContractArtifactFilename = (opts: Opts) =>
-	(sourceFile: string) => {
-		const outFile = basename(sourceFile, extname(sourceFile));
-		return join(opts.config.artifactsDir, `${outFile}.tz`);
-	};
+type TableRow = { contract: string; artifact: string };
 
-const getInputFilename = (opts: Opts) =>
-	(sourceFile: string) => {
-		return join(opts.config.contractsDir, sourceFile);
-	};
+const getInputFilename = (parsedArgs: Opts, sourceFile: string): string =>
+	join(parsedArgs.config.contractsDir, sourceFile);
 
-const getCompileCommand = (opts: Opts) =>
-	(sourceFile: string) => {
-		const projectDir = process.env.PROJECT_DIR ?? opts.projectDir;
+const getOutputFilename = (parsedArgs: Opts, sourceFile: string): string => {
+	const outputFile = basename(sourceFile, extname(sourceFile));
+	return join(parsedArgs.config.artifactsDir, `${outputFile}.tz`);
+};
 
-		if (!projectDir) throw `No project directory provided`;
+const getCompileContractCmd = (parsedArgs: Opts, sourceFile: string): string => {
+	const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
+	if (!projectDir) throw `No project directory provided`;
+	const baseCmd =
+		`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project ligolang/ligo:next compile contract`;
+	const inputFile = getInputFilename(parsedArgs, sourceFile);
+	const outputFile = `-o ${getOutputFilename(parsedArgs, sourceFile)}`;
+	const cmd = `${baseCmd} ${inputFile} ${outputFile}`;
+	return cmd;
+};
 
-		const inputFile = getInputFilename(opts)(sourceFile);
-		const baseCommand =
-			`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project -u $(id -u):$(id -g) ligolang/ligo:next compile contract ${inputFile}`;
-		const entryPoint = opts.entrypoint ? `-e ${opts.entrypoint}` : '';
-		const syntax = opts['syntax'] ? `-s ${opts['syntax']} : ""` : '';
-		const outFile = `-o ${getContractArtifactFilename(opts)(sourceFile)}`;
-		const cmd = `${baseCommand} ${entryPoint} ${syntax} ${outFile}`;
-		return cmd;
-	};
+const compileContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =>
+	getArch()
+		.then(() => getCompileContractCmd(parsedArgs, sourceFile))
+		.then(execCmd)
+		.then(({ stderr }) => {
+			if (stderr.length > 0) sendErr(stderr);
+			return {
+				contract: sourceFile,
+				artifact: getOutputFilename(parsedArgs, sourceFile),
+			};
+		})
+		.catch(err => {
+			sendErr(' ');
+			sendErr(err.message.split('\n').slice(1).join('\n'));
+			return Promise.resolve({
+				contract: sourceFile,
+				artifact: 'Not compiled',
+			});
+		});
 
-const compileContract = (opts: Opts) =>
-	(sourceFile: string): Promise<{ contract: string; artifact: string }> =>
+// Get the contract name that the storage file is associated with
+// e.g. If sourceFile is token.storages.mligo, then it'll return token.mligo
+const getContractNameForStorage = (sourceFile: string): string =>
+	sourceFile.match(/.+(?=\.storages\.(ligo|religo|mligo|jsligo))/)!.join('.');
+
+// If sourceFile is token.storages.mligo, then it'll return token.storage.{storageName}.tz
+const getOutputStorageFileName = (parsedArgs: Opts, sourceFile: string, storageName: string): string => {
+	const contractName = basename(getContractNameForStorage(sourceFile), extname(sourceFile));
+	const outputFile = `${contractName}.storage.${storageName}.tz`;
+	return join(parsedArgs.config.artifactsDir, `${outputFile}`);
+};
+
+const getCompileStorageCmd = (parsedArgs: Opts, sourceFile: string, storageName: string): string => {
+	const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
+	if (!projectDir) throw `No project directory provided`;
+	const baseCmd =
+		`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project ligolang/ligo:next compile storage`;
+	const inputFile = getInputFilename(parsedArgs, sourceFile);
+	const outputFile = `-o ${getOutputStorageFileName(parsedArgs, sourceFile, storageName)}`;
+	const cmd = `${baseCmd} ${inputFile} ${storageName} ${outputFile}`;
+	return cmd;
+};
+
+const compileStorage = (parsedArgs: Opts, sourceFile: string) =>
+	(storageName: string): Promise<TableRow> =>
 		getArch()
-			.then(() => getCompileCommand(opts)(sourceFile))
+			.then(() => getCompileStorageCmd(parsedArgs, sourceFile, storageName))
 			.then(execCmd)
-			.then(({ stderr }) => { // How should we output warnings?
+			.then(({ stderr }) => {
 				if (stderr.length > 0) sendErr(stderr);
 				return {
 					contract: sourceFile,
-					artifact: getContractArtifactFilename(opts)(sourceFile),
+					artifact: getOutputStorageFileName(parsedArgs, sourceFile, storageName),
 				};
 			})
 			.catch(err => {
@@ -56,30 +93,116 @@ const compileContract = (opts: Opts) =>
 				});
 			});
 
-const compileAll = (parsedArgs: Opts) =>
-	Promise.all(getContracts(/\.(ligo|religo|mligo|jsligo)$/, parsedArgs.config))
-		.then(entries => entries.map(compileContract(parsedArgs)))
-		.then(processes => {
-			if (processes.length > 0) return processes;
-			return [];
+const compileStorages = (parsedArgs: Opts, sourceFile: string): Promise<TableRow[]> =>
+	readFile(getInputFilename(parsedArgs, sourceFile), 'utf8')
+		.then(data => {
+			if (!data.includes('#include')) {
+				writeFile(
+					getInputFilename(parsedArgs, sourceFile),
+					`#include "${getContractNameForStorage(sourceFile)}"\n` + data,
+					'utf8',
+				);
+			}
+			return data;
 		})
-		.then(promises => Promise.all(promises));
+		.then(data => data.match(/(?<=\s*(let|const)\s+)[a-zA-Z0-9_]+/g))
+		.then(storageNames =>
+			storageNames
+				? Promise.all(storageNames.map(compileStorage(parsedArgs, sourceFile)))
+				: Promise.resolve([])
+		);
 
-export const compile = (parsedArgs: Opts) => {
-	const p = parsedArgs.sourceFile
-		? compileContract(parsedArgs)(parsedArgs.sourceFile as string)
-			.then(result => [result])
-		: compileAll(parsedArgs)
-			.then(results => {
-				if (results.length === 0) {
-					sendErr('No contracts found to compile. Have you run "taq add-contract [sourceFile]" ?');
-				}
-				return results;
+// Get the contract name that the parameter file is associated with
+// e.g. If sourceFile is token.parameters.mligo, then it'll return token.mligo
+const getContractNameForParameter = (sourceFile: string): string =>
+	sourceFile.match(/.+(?=\.parameters\.(ligo|religo|mligo|jsligo))/)!.join('.');
+
+// If sourceFile is token.parameters.mligo, then it'll return token.parameter.{parameterName}.tz
+const getOutputParameterFileName = (parsedArgs: Opts, sourceFile: string, parameterName: string): string => {
+	const contractName = basename(getContractNameForParameter(sourceFile), extname(sourceFile));
+	const outputFile = `${contractName}.parameter.${parameterName}.tz`;
+	return join(parsedArgs.config.artifactsDir, `${outputFile}`);
+};
+
+const getCompileParameterCmd = (parsedArgs: Opts, sourceFile: string, parameterName: string): string => {
+	const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
+	if (!projectDir) throw `No project directory provided`;
+	const baseCmd =
+		`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project ligolang/ligo:next compile parameter`;
+	const inputFile = getInputFilename(parsedArgs, sourceFile);
+	const outputFile = `-o ${getOutputParameterFileName(parsedArgs, sourceFile, parameterName)}`;
+	const cmd = `${baseCmd} ${inputFile} ${parameterName} ${outputFile}`;
+	return cmd;
+};
+
+const compileParameter = (parsedArgs: Opts, sourceFile: string) =>
+	(parameterName: string): Promise<TableRow> =>
+		getArch()
+			.then(() => getCompileParameterCmd(parsedArgs, sourceFile, parameterName))
+			.then(execCmd)
+			.then(({ stderr }) => {
+				if (stderr.length > 0) sendErr(stderr);
+				return {
+					contract: sourceFile,
+					artifact: getOutputParameterFileName(parsedArgs, sourceFile, parameterName),
+				};
+			})
+			.catch(err => {
+				sendErr(' ');
+				sendErr(err.message.split('\n').slice(1).join('\n'));
+				return Promise.resolve({
+					contract: sourceFile,
+					artifact: 'Not compiled',
+				});
 			});
 
-	return p
-		.then(sendJsonRes)
-		.catch(err => sendAsyncErr(err, false));
+const compileParameters = (parsedArgs: Opts, sourceFile: string): Promise<TableRow[]> =>
+	readFile(getInputFilename(parsedArgs, sourceFile), 'utf8')
+		.then(data => {
+			if (!data.includes('#include')) {
+				writeFile(
+					getInputFilename(parsedArgs, sourceFile),
+					`#include "${getContractNameForParameter(sourceFile)}"\n` + data,
+					'utf8',
+				);
+			}
+			return data;
+		})
+		.then(data => data.match(/(?<=\s*(let|const)\s+)[a-zA-Z0-9_]+/g))
+		.then(parameterNames =>
+			parameterNames
+				? Promise.all(parameterNames.map(compileParameter(parsedArgs, sourceFile)))
+				: Promise.resolve([])
+		);
+
+const mergeArtifactsOutput = (sourceFile: string) =>
+	(tableRows: TableRow[]): TableRow[] => {
+		const artifactsOutput = tableRows.reduce(
+			(acc: string, row: TableRow) => row.artifact === 'Not compiled' ? acc : `${acc}${row.artifact}\n`,
+			'',
+		);
+		return [{
+			contract: sourceFile,
+			artifact: artifactsOutput,
+		}];
+	};
+
+const isStoragesFile = (sourceFile: string): boolean => /.+\.storages\.(ligo|religo|mligo|jsligo)$/.test(sourceFile);
+
+const isParametersFile = (sourceFile: string): boolean =>
+	/.+\.parameters\.(ligo|religo|mligo|jsligo)$/.test(sourceFile);
+
+export const compile = (parsedArgs: Opts) => {
+	const sourceFile: string = parsedArgs.sourceFile;
+	let p: Promise<TableRow[]>;
+	if (isStoragesFile(sourceFile)) {
+		p = compileStorages(parsedArgs, sourceFile).then(mergeArtifactsOutput(sourceFile));
+	} else if (isParametersFile(sourceFile)) {
+		p = compileParameters(parsedArgs, sourceFile).then(mergeArtifactsOutput(sourceFile));
+	} else {
+		p = compileContract(parsedArgs, sourceFile).then(result => [result]);
+	}
+	return p.then(sendJsonRes).catch(err => sendAsyncErr(err, false));
 };
 
 export default compile;

--- a/taqueria-plugin-ligo/index.ts
+++ b/taqueria-plugin-ligo/index.ts
@@ -1,6 +1,6 @@
 import { Option, Plugin, PositionalArg, Task, Template } from '@taqueria/node-sdk';
-import compile from './compile';
 import createContract from './createContract';
+import ligo from './ligo';
 
 Plugin.create(i18n => ({
 	schema: '1.0',
@@ -11,7 +11,8 @@ Plugin.create(i18n => ({
 			task: 'compile',
 			command: 'compile [sourceFile]',
 			aliases: ['c', 'compile-ligo'],
-			description: 'Compile a smart contract written in a Ligo syntax to Michelson code',
+			description:
+				'Compile a smart contract written in a LIGO syntax to Michelson code, along with its associated storages and parameters files if they are found',
 			handler: 'proxy',
 			encoding: 'json',
 		}),
@@ -39,5 +40,5 @@ Plugin.create(i18n => ({
 			handler: createContract,
 		}),
 	],
-	proxy: compile,
+	proxy: ligo,
 }), process.argv);

--- a/taqueria-plugin-ligo/index.ts
+++ b/taqueria-plugin-ligo/index.ts
@@ -12,23 +12,6 @@ Plugin.create(i18n => ({
 			command: 'compile [sourceFile]',
 			aliases: ['c', 'compile-ligo'],
 			description: 'Compile a smart contract written in a Ligo syntax to Michelson code',
-			options: [
-				Option.create({
-					shortFlag: 'e',
-					flag: 'entrypoint',
-					description: 'The entry point that will be compiled',
-				}),
-				Option.create({
-					shortFlag: 's',
-					flag: 'syntax',
-					description: 'The syntax used in the contract',
-				}),
-				Option.create({
-					shortFlag: 'i',
-					flag: 'infer',
-					description: 'Enable type inference',
-				}),
-			],
 			handler: 'proxy',
 			encoding: 'json',
 		}),

--- a/taqueria-plugin-ligo/ligo.ts
+++ b/taqueria-plugin-ligo/ligo.ts
@@ -1,0 +1,20 @@
+import { sendAsyncErr } from '@taqueria/node-sdk';
+import { RequestArgs } from '@taqueria/node-sdk/types';
+import compile from './compile';
+
+interface Opts extends RequestArgs.ProxyRequestArgs {
+	sourceFile: string;
+}
+
+export const ligo = (parsedArgs: Opts): Promise<void> => {
+	switch (parsedArgs.task) {
+		case 'compile':
+			return compile(parsedArgs);
+		// case 'test':
+		// 	return test(parsedArgs); // TODO: to be implemented in the future
+		default:
+			return sendAsyncErr(`${parsedArgs.task} is not an understood task by the LIGO plugin`);
+	}
+};
+
+export default ligo;

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -112,6 +112,13 @@ export const sendErr = (msg: string, newline = true) => {
 		: process.stderr.write(msg) as unknown as void;
 };
 
+export const sendWarn = (msg: string, newline = true) => {
+	if (!msg || msg.length === 0) return;
+	return newline
+		? console.warn(msg)
+		: process.stderr.write(msg) as unknown as void;
+};
+
 export const sendAsyncErr = (msg: string, newline = true) => Promise.reject(sendErr(msg, newline)); // should this be Promise.reject?
 
 export const sendJson = (msg: unknown, newline = true) => sendRes(JSON.stringify(msg), newline);

--- a/tests/e2e/taqueria-cli-scaffolding-functional.spec.ts
+++ b/tests/e2e/taqueria-cli-scaffolding-functional.spec.ts
@@ -25,10 +25,10 @@ describe('E2E Testing for taqueria scaffolding initialization,', () => {
 	});
 
 	test('Verify that scaffold project can start and stop taqueria locally', async () => {
-		const startResults = await exec(`taq start sandbox local`, {cwd: `${scaffoldDirName}`});
+		const startResults = await exec(`taq start sandbox local`, { cwd: `${scaffoldDirName}` });
 		expect(startResults.stdout).toContain('Started local.');
 
-		const stopResults = await exec(`taq stop sandbox local`, {cwd: `${scaffoldDirName}`});
+		const stopResults = await exec(`taq stop sandbox local`, { cwd: `${scaffoldDirName}` });
 		expect(stopResults.stdout).toContain('Stopped local.');
 	});
 

--- a/tests/e2e/taqueria-cli-scaffolding-init.spec.ts
+++ b/tests/e2e/taqueria-cli-scaffolding-init.spec.ts
@@ -24,7 +24,7 @@ describe('E2E Testing for taqueria scaffolding initialization,', () => {
 			try {
 				await fsPromises.rm(`./${scaffoldDirName}`, { recursive: true, force: true });
 			} catch {
-				// Ensure that this path doesn't already exist 
+				// Ensure that this path doesn't already exist
 			}
 
 			await exec('taq scaffold');


### PR DESCRIPTION
# 🏗️ PR ➾

Fixes #1168 

## 🪂 Pre-Merge Checklist

- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [x] 🏄‍♂️ Myself and others have built this branch and done manual testing on the change
- [x] ⛵ A summary describing the change has been written for release notes

----------------------------------------------------------------------------------------------------------------------------

## 🪁 Description

We did not have means to compile storages and parameters in the LIGO plugin. This change adds those features by introducing a naming convention. e.g. `taq compile hello.mligo` will compile the contract like before, but `taq compile hello.storages.mligo` and `taq compile hello.parameters.mligo` will compile the LIGO storage and parameter expressions defined in those files respectively. Furthermore, contract compilation will automatically perform compilation of its associated "storages" and "parameters" files.

## 🎢 Test Plan

Please describe the testing strategy for this change

----------------------------------------------------------------------------------------------------------------------------

### 🛸 Type of Change

- [ ] 🐟 Minor change (non-breaking change of very limited scope)
- [ ] 🦑 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🌊 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🐳 Major refactor (breaking changes and significant impact to the codebase)

----------------------------------------------------------------------------------------------------------------------------
