### PR TITLE
Fix Jest plugin dependency issue

### DIFF
--- a/taqueria-plugin-jest/package.json
+++ b/taqueria-plugin-jest/package.json
@@ -32,14 +32,14 @@
 		"async-retry": "^1.3.3",
 		"execa": "^6.1.0",
 		"fast-glob": "^3.2.7",
-		"jest-config": "^28.1.0"
+		"jest-config": "^28.1.0",
+		"jest": "^28.1.0"
 	},
 	"devDependencies": {
 		"@types/async-retry": "^1.3.3",
 		"@types/jest": "^27.5.1",
 		"tsup": "^6.1.3",
 		"typescript": "4.7.2",
-		"jest": "^28.1.0",
 		"jest-cli": "^28.1.0"
 	},
 	"tsup": {


### PR DESCRIPTION
# 🏗️ PR ➾

Fixes # (issue)

## 🪂 Pre-Merge Checklist

- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🏄‍♂️ Myself and others have built this branch and done manual testing on the change

----------------------------------------------------------------------------------------------------------------------------

## 🪁 Description

Currently, the Jest plugin has an issue that when installed in a project that exists outside the Taqueria repo, the user receives an error that Jest is not installed. The working hypothesis is that this is due to a devDependency for Jest, Jest-CLI, or @types/jest needs to be in dependencies

## 🎢 Test Plan

N/A

----------------------------------------------------------------------------------------------------------------------------

### 🛸 Type of Change

- [ ] 🐟 Minor change (non-breaking change of very limited scope)
- [x] 🦑 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🌊 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🐳 Major refactor (breaking changes and significant impact to the codebase)

----------------------------------------------------------------------------------------------------------------------------
