### PR TITLE
fix(docs): '--version' output show version 0.16.0

### DIFF
--- a/website/docs/getting-started/installation.mdx
+++ b/website/docs/getting-started/installation.mdx
@@ -243,7 +243,7 @@ taq --version
 You should see the version of Taqueria installed output:
 
 ```shell
-v0.10.0
+v0.16.0
 ```
 
 If you see this, you have successfully installed the Taqueria CLI!


### PR DESCRIPTION
# 🏗️ PR ➾ fix(docs): '--version' output show version 0.16.0


## 🪂 Pre-Merge Checklist

- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] ⛵ A summary describing the change has been written for release notes

----------------------------------------------------------------------------------------------------------------------------

## 🪁 Description

The quickstart page of the website and docs needs to be updated to reflect the version number change. Currently the docs indicate that when a user runs `taq --version`, the output with show `v0.10.0`. This is not the case and needs to be updated to `v0.16.0`. For future releases, this file needs to be updated with the release version number.

### 🛸 Type of Change

- [x] 🐟 Minor change (non-breaking change of very limited scope)
- [ ] 🦑 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🌊 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🐳 Major refactor (breaking changes and significant impact to the codebase)

----------------------------------------------------------------------------------------------------------------------------
