### PR TITLE
Fix build issues for taqueria-protocol on node v16.16.0+

### DIFF
--- a/taqueria-protocol/package.json
+++ b/taqueria-protocol/package.json
@@ -5,7 +5,7 @@
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"build": "npx tsc -noEmit -p ./tsconfig.json && npx tsup"
+		"build": "npx tsc --emitDeclarationOnly -p ./tsconfig.json && npx tsup"
 	},
 	"keywords": [
 		"taqueria",
@@ -57,7 +57,7 @@
 		"sourcemap": true,
 		"target": "node16",
 		"outDir": "./",
-		"dts": true,
+		"dts": false,
 		"clean": false,
 		"skipNodeModulesBundle": true,
 		"platform": "node",

--- a/taqueria-protocol/tsconfig.json
+++ b/taqueria-protocol/tsconfig.json
@@ -42,9 +42,9 @@
 		// "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
 
 		/* Emit */
-		// "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-		// "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-		// "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+		"declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+		"declarationMap": true, /* Create sourcemaps for d.ts files. */
+		"emitDeclarationOnly": true, /* Only output d.ts files and not JavaScript files. */
 		// "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
 		// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
 		// "outDir": "./",                                   /* Specify an output folder for all emitted files. */


### PR DESCRIPTION
# 🏗️ PR ➾

Fixes an issue where Taqueria Protocol cannot be built on Node v16.16.0 or later - v16.5.0 appears to work fine.

## 🪂 Pre-Merge Checklist

- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🏄‍♂️ Myself and others have built this branch and done manual testing on the change
- [ ] ⛵ A summary describing the change has been written for release notes

----------------------------------------------------------------------------------------------------------------------------

## 🪁 Description

tsup is used to build our bundle and dts files. However, tsup defers dts generation to rollup-plugin-dts, which appears to be having issues with the latest version of node. Thus, I've adjusted our build routine for the protocol package to use the typescript compiler for dts file generation, and use tsup for everything else.

## 🎢 Test Plan

Asking Alex to build locally on specific versions of NodeJS.

----------------------------------------------------------------------------------------------------------------------------

### 🛸 Type of Change

- [ ] 🐟 Minor change (non-breaking change of very limited scope)
- [ ] 🦑 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🌊 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🐳 Major refactor (breaking changes and significant impact to the codebase)

----------------------------------------------------------------------------------------------------------------------------
