### PR TITLE
Add test task for ligo plugin

### DIFF
--- a/taqueria-plugin-ligo/README.md
+++ b/taqueria-plugin-ligo/README.md
@@ -54,6 +54,73 @@ Lastly, `taq compile hello.mligo` will compile `hello.mligo` and emit `hello.tz`
 
 None for now.
 
+## The `taq test` Task
+
+Basic usage is:
+
+```shell
+taq test <filename>
+```
+
+### Basic description
+This task tests the LIGO source code and ouputs a result suggesting a failure or success. Normally you'd have a contract file and a separate test file that includes the contract's code, both within the `/contracts` directory.
+
+For example, refer to the following 2 code snippets:
+```ligo title="counter.mligo"
+type storage = int
+
+type parameter =
+  Increment of int
+| Decrement of int
+| Reset
+
+type return = operation list * storage
+
+// Two entrypoints
+
+let add (store, delta : storage * int) : storage = store + delta
+let sub (store, delta : storage * int) : storage = store - delta
+
+(* Main access point that dispatches to the entrypoints according to
+   the smart contract parameter. *)
+
+let main (action, store : parameter * storage) : return =
+ ([] : operation list),    // No operations
+ (match action with
+   Increment (n) -> add (store, n)
+ | Decrement (n) -> sub (store, n)
+ | Reset         -> 0)
+```
+
+```ligo title="testCounter.mligo"
+#include "counter.mligo"
+
+let initial_storage = 42
+
+let test_initial_storage =
+ let (taddr, _, _) = Test.originate main initial_storage 0tez in
+ assert (Test.get_storage taddr = initial_storage)
+
+let test_increment =
+ let (taddr, _, _) = Test.originate main initial_storage 0tez in
+ let contr = Test.to_contract taddr in
+ let _ = Test.transfer_to_contract_exn contr (Increment 1) 1mutez in
+ assert (Test.get_storage taddr = initial_storage + 1)
+```
+
+By running `taq test testCounter.mligo`, you should get the following:
+```
+┌───────────────────┬──────────────────────────────────────────────┐
+│ Contract          │ Test Results                                 │
+├───────────────────┼──────────────────────────────────────────────┤
+│ testCounter.mligo │ Everything at the top-level was executed.    │
+│                   │ - test_initial_storage exited with value (). │
+│                   │ - test_increment exited with value ().       │
+│                   │                                              │
+│                   │ 🎉 All tests passed 🎉                        │
+└───────────────────┴──────────────────────────────────────────────┘
+```
+
 ## Template creation
 The LIGO plugin also exposes a contract template via the `taq create contract <contractName>` task. This task will create a new LIGO contract in the `contracts` directory, insert some boilerplate LIGO contract code and will register the contract with Taqueria
 

--- a/taqueria-plugin-ligo/_readme.eta
+++ b/taqueria-plugin-ligo/_readme.eta
@@ -59,6 +59,73 @@ Make sure you name it `hello.storages.mligo` and not `hello.storage.mligo` (note
 
 None for now.
 
+## The `taq test` Task
+
+Basic usage is:
+
+```shell
+taq test <filename>
+```
+
+### Basic description
+This task tests the LIGO source code and ouputs a result suggesting a failure or success. Normally you'd have a contract file and a separate test file that includes the contract's code, both within the `/contracts` directory.
+
+For example, refer to the following 2 code snippets:
+```ligo title="counter.mligo"
+type storage = int
+
+type parameter =
+  Increment of int
+| Decrement of int
+| Reset
+
+type return = operation list * storage
+
+// Two entrypoints
+
+let add (store, delta : storage * int) : storage = store + delta
+let sub (store, delta : storage * int) : storage = store - delta
+
+(* Main access point that dispatches to the entrypoints according to
+   the smart contract parameter. *)
+
+let main (action, store : parameter * storage) : return =
+ ([] : operation list),    // No operations
+ (match action with
+   Increment (n) -> add (store, n)
+ | Decrement (n) -> sub (store, n)
+ | Reset         -> 0)
+```
+
+```ligo title="testCounter.mligo"
+#include "counter.mligo"
+
+let initial_storage = 42
+
+let test_initial_storage =
+ let (taddr, _, _) = Test.originate main initial_storage 0tez in
+ assert (Test.get_storage taddr = initial_storage)
+
+let test_increment =
+ let (taddr, _, _) = Test.originate main initial_storage 0tez in
+ let contr = Test.to_contract taddr in
+ let _ = Test.transfer_to_contract_exn contr (Increment 1) 1mutez in
+ assert (Test.get_storage taddr = initial_storage + 1)
+```
+
+By running `taq test testCounter.mligo`, you should get the following:
+```
+┌───────────────────┬──────────────────────────────────────────────┐
+│ Contract          │ Test Results                                 │
+├───────────────────┼──────────────────────────────────────────────┤
+│ testCounter.mligo │ Everything at the top-level was executed.    │
+│                   │ - test_initial_storage exited with value (). │
+│                   │ - test_increment exited with value ().       │
+│                   │                                              │
+│                   │ 🎉 All tests passed 🎉                        │
+└───────────────────┴──────────────────────────────────────────────┘
+```
+
 ## Template creation
 The LIGO plugin also exposes a contract template via the `taq create contract <contractName>` task. This task will create a new LIGO contract in the `contracts` directory, insert some boilerplate LIGO contract code and will register the contract with Taqueria
 

--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -161,7 +161,7 @@ const compileExprs = (parsedArgs: Opts, sourceFile: string, exprKind: ExprKind):
 		})
 		.then(mergeArtifactsOutput(sourceFile));
 
-const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFile: string) => {
+const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFile: string): Promise<TableRow[]> => {
 	const contractCompileResult = await compileContract(parsedArgs, sourceFile);
 	if (contractCompileResult.artifact === COMPILE_ERR_MSG) return [contractCompileResult];
 
@@ -226,7 +226,6 @@ const mergeArtifactsOutput = (sourceFile: string) =>
 
 export const compile = (parsedArgs: Opts): Promise<void> => {
 	const sourceFile = parsedArgs.sourceFile;
-	if (!sourceFile) return sendAsyncErr('No source file specified.');
 	let p: Promise<TableRow[]>;
 	if (isStoragesFile(sourceFile)) p = compileExprs(parsedArgs, sourceFile, 'storage');
 	else if (isParametersFile(sourceFile)) p = compileExprs(parsedArgs, sourceFile, 'parameter');

--- a/taqueria-plugin-ligo/index.ts
+++ b/taqueria-plugin-ligo/index.ts
@@ -16,6 +16,13 @@ Plugin.create(i18n => ({
 			handler: 'proxy',
 			encoding: 'json',
 		}),
+		Task.create({
+			task: 'test',
+			command: 'test <sourceFile>',
+			description: 'Test a smart contract written in LIGO',
+			handler: 'proxy',
+			encoding: 'json',
+		}),
 	],
 	templates: [
 		Template.create({

--- a/taqueria-plugin-ligo/ligo.ts
+++ b/taqueria-plugin-ligo/ligo.ts
@@ -1,6 +1,7 @@
 import { sendAsyncErr } from '@taqueria/node-sdk';
 import { RequestArgs } from '@taqueria/node-sdk/types';
 import compile from './compile';
+import { test } from './test';
 
 interface Opts extends RequestArgs.ProxyRequestArgs {
 	sourceFile: string;
@@ -10,8 +11,8 @@ export const ligo = (parsedArgs: Opts): Promise<void> => {
 	switch (parsedArgs.task) {
 		case 'compile':
 			return compile(parsedArgs);
-		// case 'test':
-		// 	return test(parsedArgs); // TODO: to be implemented in the future
+		case 'test':
+			return test(parsedArgs);
 		default:
 			return sendAsyncErr(`${parsedArgs.task} is not an understood task by the LIGO plugin`);
 	}

--- a/taqueria-plugin-ligo/test.ts
+++ b/taqueria-plugin-ligo/test.ts
@@ -1,0 +1,53 @@
+import { execCmd, getArch, sendAsyncErr, sendErr, sendJsonRes, sendWarn } from '@taqueria/node-sdk';
+import { RequestArgs } from '@taqueria/node-sdk/types';
+import { access, readFile, writeFile } from 'fs/promises';
+import { basename, extname, join } from 'path';
+
+interface Opts extends RequestArgs.t {
+	sourceFile: string;
+}
+
+type TableRow = { contract: string; testResults: string };
+
+const getInputFilename = (parsedArgs: Opts, sourceFile: string): string =>
+	join(parsedArgs.config.contractsDir, sourceFile);
+
+const getTestContractCmd = (parsedArgs: Opts, sourceFile: string): string => {
+	const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
+	if (!projectDir) throw `No project directory provided`;
+	const baseCmd =
+		`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project -u $(id -u):$(id -g) ligolang/ligo:next run test`;
+	const inputFile = getInputFilename(parsedArgs, sourceFile);
+	const cmd = `${baseCmd} ${inputFile}`;
+	return cmd;
+};
+
+const testContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =>
+	getArch()
+		.then(() => getTestContractCmd(parsedArgs, sourceFile))
+		.then(execCmd)
+		.then(({ stdout, stderr }) => {
+			if (stderr.length > 0) sendWarn(stderr);
+			const result = '🎉 All tests passed 🎉';
+			return {
+				contract: sourceFile,
+				testResults: stdout.length > 0 ? `${stdout}\n${result}` : result,
+			};
+		})
+		.catch(err => {
+			sendErr(`\n=== For ${sourceFile} ===`);
+			sendErr(err.message.replace(/Command failed.+?\n/, ''));
+			return {
+				contract: sourceFile,
+				testResults: 'Some tests failed :(',
+			};
+		});
+
+export const test = (parsedArgs: Opts): Promise<void> => {
+	const sourceFile = parsedArgs.sourceFile;
+	return testContract(parsedArgs, sourceFile).then(results => [results]).then(sendJsonRes).catch(err =>
+		sendAsyncErr(err, false)
+	);
+};
+
+export default test;

--- a/taqueria-plugin-ligo/test.ts
+++ b/taqueria-plugin-ligo/test.ts
@@ -1,7 +1,6 @@
 import { execCmd, getArch, sendAsyncErr, sendErr, sendJsonRes, sendWarn } from '@taqueria/node-sdk';
 import { RequestArgs } from '@taqueria/node-sdk/types';
-import { access, readFile, writeFile } from 'fs/promises';
-import { basename, extname, join } from 'path';
+import { join } from 'path';
 
 interface Opts extends RequestArgs.t {
 	sourceFile: string;

--- a/taqueria-plugin-ligo/test.ts
+++ b/taqueria-plugin-ligo/test.ts
@@ -45,7 +45,7 @@ const testContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =
 
 export const test = (parsedArgs: Opts): Promise<void> => {
 	const sourceFile = parsedArgs.sourceFile;
-	return testContract(parsedArgs, sourceFile).then(results => [results]).then(sendJsonRes).catch(err =>
+	return testContract(parsedArgs, sourceFile).then(result => [result]).then(sendJsonRes).catch(err =>
 		sendAsyncErr(err, false)
 	);
 };

--- a/tests/e2e/data/hello-tacos-invalid-tests.mligo
+++ b/tests/e2e/data/hello-tacos-invalid-tests.mligo
@@ -1,0 +1,13 @@
+#include "hello-tacos.mligo"
+
+let available_tacos = 100
+
+let test_available_tacos =
+ let (taddr, _, _) = Test.originate main initial_storage 100tez in
+ assert (Test.get_storage taddr = available_tacos)
+
+let test_buy_tacos =
+ let (taddr, _, _) = Test.originate main initial_storage 100tez in
+ let contr = Test.to_contract taddr in
+ let _ = Test.transfer_to_contract_exn contr 1mutez in
+ assert (Test.get_storage taddr = test_available_tacos  - 1)

--- a/tests/e2e/data/hello-tacos-tests.mligo
+++ b/tests/e2e/data/hello-tacos-tests.mligo
@@ -1,0 +1,13 @@
+#include "hello-tacos.mligo"
+
+let available_tacos = 100n
+
+let test_available_tacos =
+ let (taddr, _, _) = Test.originate main available_tacos 100tez in
+ assert (Test.get_storage taddr = available_tacos)
+
+let test_buy_tacos =
+ let (taddr, _, _) = Test.originate main available_tacos 100tez in
+ let contr = Test.to_contract taddr in
+ let _ = Test.transfer_to_contract_exn contr 1n in
+ assert (Test.get_storage taddr = 100n)

--- a/tests/e2e/data/hello-tacos-tests.mligo
+++ b/tests/e2e/data/hello-tacos-tests.mligo
@@ -7,7 +7,6 @@ let test_available_tacos =
  assert (Test.get_storage taddr = available_tacos)
 
 let test_buy_tacos =
- let (taddr, _, _) = Test.originate main available_tacos 100tez in
- let contr = Test.to_contract taddr in
- let _ = Test.transfer_to_contract_exn contr 1n in
- assert (Test.get_storage taddr = 100n)
+ let res = main(1n, available_tacos) in (* The nature of the contract we don't have entrypoints
+ // The only way to test it is to call function itself *)
+ assert (res.1 = 99n)

--- a/tests/e2e/data/help-contents/help-contents.ts
+++ b/tests/e2e/data/help-contents/help-contents.ts
@@ -54,6 +54,7 @@ Commands:
   taq list-contracts              List registered contracts
   taq compile                     Provided by more than one plugin. The option -
                                   -plugin is required.
+  taq test <sourceFile>           Test a smart contract written in LIGO
   taq create <template>           Create files from pre-existing templates
 
 Options:
@@ -96,6 +97,7 @@ Commands:
   taq list-contracts              List registered contracts
   taq compile                     Provided by more than one plugin. The option -
                                   -plugin is required.
+  taq test <sourceFile>           Test a smart contract written in LIGO
   taq create <template>           Create files from pre-existing templates
 
 Options:

--- a/tests/e2e/data/help-contents/ligo-contents.ts
+++ b/tests/e2e/data/help-contents/ligo-contents.ts
@@ -13,6 +13,7 @@ Commands:
                                   tax to Michelson code, along with its associat
                                   ed storages and parameters files if they are f
                                   ound                [aliases: c, compile-ligo]
+  taq test <sourceFile>           Test a smart contract written in LIGO
   taq create <template>           Create files from pre-existing templates
 
 Options:

--- a/tests/e2e/taqueria-plugin-ligo.spec.ts
+++ b/tests/e2e/taqueria-plugin-ligo.spec.ts
@@ -19,7 +19,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		} catch (_) {}
 	});
 
-	test.skip('Verify that the ligo plugin exposes the associated commands in the help menu', async () => {
+	test('Verify that the ligo plugin exposes the associated commands in the help menu', async () => {
 		try {
 			const ligoHelpContents = await exec(`taq --help --projectDir=${taqueriaProjectPath}`);
 			expect(ligoHelpContents.stdout).toBe(contents.helpContentsLigoPlugin);
@@ -28,7 +28,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test.skip('Verify that the ligo plugin exposes the associated options in the help menu', async () => {
+	test('Verify that the ligo plugin exposes the associated options in the help menu', async () => {
 		try {
 			const ligoHelpContents = await exec(`taq compile --help --projectDir=${taqueriaProjectPath}`);
 			expect(ligoHelpContents.stdout).toBe(contents.helpContentsLigoPluginSpecific);
@@ -37,7 +37,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test.skip('Verify that the ligo plugin aliases expose the correct info in the help menu', async () => {
+	test('Verify that the ligo plugin aliases expose the correct info in the help menu', async () => {
 		try {
 			const ligoAliasCHelpContents = await exec(`taq c --help --projectDir=${taqueriaProjectPath}`);
 			expect(ligoAliasCHelpContents.stdout).toBe(contents.helpContentsLigoPluginSpecific);
@@ -51,7 +51,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test.skip('Verify that taqueria ligo plugin outputs no contracts message if no contracts exist', async () => {
+	test('Verify that taqueria ligo plugin outputs no contracts message if no contracts exist', async () => {
 		try {
 			await exec(`taq compile`, { cwd: `./${taqueriaProjectPath}` });
 		} catch (error) {
@@ -59,7 +59,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test.skip('Verify that taqueria ligo plugin throw an error message if contract name is not specified', async () => {
+	test('Verify that taqueria ligo plugin throw an error message if contract name is not specified', async () => {
 		try {
 			// 1. Copy contract from data folder to taqueria project folder
 			await exec(`cp e2e/data/hello-tacos.mligo ${taqueriaProjectPath}/contracts`);
@@ -75,7 +75,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test.skip('Verify that taqueria ligo plugin can compile one contract using compile [sourceFile] command', async () => {
+	test('Verify that taqueria ligo plugin can compile one contract using compile [sourceFile] command', async () => {
 		try {
 			// 1. Copy contract from data folder to taqueria project folder
 			await exec(`cp e2e/data/hello-tacos.mligo ${taqueriaProjectPath}/contracts`);
@@ -114,7 +114,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test.skip('Verify that taqueria ligo plugin will display proper message if user tries to compile contract that does not exist', async () => {
+	test('Verify that taqueria ligo plugin will display proper message if user tries to compile contract that does not exist', async () => {
 		try {
 			// 1. Run taq compile ${contractName} for contract that does not exist
 			const { stdout, stderr } = await exec(`taq compile test.mligo`, { cwd: `./${taqueriaProjectPath}` });
@@ -129,7 +129,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test.skip('Verify that taqueria ligo plugin emits error and yet displays table if contract is invalid', async () => {
+	test('Verify that taqueria ligo plugin emits error and yet displays table if contract is invalid', async () => {
 		try {
 			await exec(`cp e2e/data/invalid-contract.mligo ${taqueriaProjectPath}/contracts`);
 			await exec(`taq add-contract invalid-contract.mligo`, { cwd: `./${taqueriaProjectPath}` });
@@ -143,41 +143,41 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	// TODO:
 	test('Verify that taqueria ligo plugin can run ligo test using taq test <sourceFile> command', async () => {
 		try {
 			// 1. Copy contract  and tests files from data folder to taqueria project folder
-			await exec(`cp e2e/data/hello-tacos.mligo ${taqueriaProjectPath}/contracts`);
 			await exec(`cp e2e/data/hello-tacos-tests.mligo ${taqueriaProjectPath}/contracts`);
 
 			// 2. Run taq test ${testFileName}
 			const { stdout, stderr } = await exec(`taq test hello-tacos-tests.mligo`, { cwd: `./${taqueriaProjectPath}` });
-			console.log(stdout);
+			expect(stdout).toContain('All tests passed');
 		} catch (error) {
 			throw new Error(`error: ${error}`);
 		}
 	});
 
-	// TODO:
 	test('Verify that taqueria ligo plugin will output proper error message running taq test <sourceFile> command against invalid test file', async () => {
 		try {
 			// 1. Copy contract  and tests files from data folder to taqueria project folder
-			await exec(`cp e2e/data/hello-tacos--invalid-tests.mligo ${taqueriaProjectPath}/contracts`);
+			await exec(`cp e2e/data/hello-tacos-invalid-tests.mligo ${taqueriaProjectPath}/contracts`);
 
 			// 2. Run taq test ${testFileName}
 			// const output =   await exec(`taq test hello-tacos-invalid-tests.mligo`, { cwd: `./${taqueriaProjectPath}` });
-			console.log(await exec(`taq test hello-tacos-invalid-tests.mligo`, { cwd: `./${taqueriaProjectPath}` }));
+			const { stdout, stderr } = await exec(`taq test hello-tacos-invalid-tests.mligo`, {
+				cwd: `./${taqueriaProjectPath}`,
+			});
+			expect(stdout).toContain('Some tests failed :(');
+			expect(stderr).toContain('Variable "initial_storage" not found.');
 		} catch (error) {
 			throw new Error(`error: ${error}`);
 		}
 	});
 
-	// TODO:
 	test('Verify that taqueria ligo plugin will output proper error message running taq test <sourceFile> command against non-existing file', async () => {
 		try {
 			// 1. Run taq test ${testFileName} against file that does not exist
-			const { stdout, stderr } = await exec(`taq test hello-tacos-tests.mligo`, { cwd: `./${taqueriaProjectPath}` });
-			console.log(stderr);
+			const { stdout, stderr } = await exec(`taq test hello-tacos-test.mligo`, { cwd: `./${taqueriaProjectPath}` });
+			expect(stderr).toContain('contracts/hello-tacos-test.mligo: No such file or directory');
 		} catch (error) {
 			throw new Error(`error: ${error}`);
 		}

--- a/tests/e2e/taqueria-plugin-ligo.spec.ts
+++ b/tests/e2e/taqueria-plugin-ligo.spec.ts
@@ -19,7 +19,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		} catch (_) {}
 	});
 
-	test('Verify that the ligo plugin exposes the associated commands in the help menu', async () => {
+	test.skip('Verify that the ligo plugin exposes the associated commands in the help menu', async () => {
 		try {
 			const ligoHelpContents = await exec(`taq --help --projectDir=${taqueriaProjectPath}`);
 			expect(ligoHelpContents.stdout).toBe(contents.helpContentsLigoPlugin);
@@ -28,7 +28,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test('Verify that the ligo plugin exposes the associated options in the help menu', async () => {
+	test.skip('Verify that the ligo plugin exposes the associated options in the help menu', async () => {
 		try {
 			const ligoHelpContents = await exec(`taq compile --help --projectDir=${taqueriaProjectPath}`);
 			expect(ligoHelpContents.stdout).toBe(contents.helpContentsLigoPluginSpecific);
@@ -37,7 +37,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test('Verify that the ligo plugin aliases expose the correct info in the help menu', async () => {
+	test.skip('Verify that the ligo plugin aliases expose the correct info in the help menu', async () => {
 		try {
 			const ligoAliasCHelpContents = await exec(`taq c --help --projectDir=${taqueriaProjectPath}`);
 			expect(ligoAliasCHelpContents.stdout).toBe(contents.helpContentsLigoPluginSpecific);
@@ -51,7 +51,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test('Verify that taqueria ligo plugin outputs no contracts message if no contracts exist', async () => {
+	test.skip('Verify that taqueria ligo plugin outputs no contracts message if no contracts exist', async () => {
 		try {
 			await exec(`taq compile`, { cwd: `./${taqueriaProjectPath}` });
 		} catch (error) {
@@ -59,7 +59,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test('Verify that taqueria ligo plugin throw an error message if contract name is not specified', async () => {
+	test.skip('Verify that taqueria ligo plugin throw an error message if contract name is not specified', async () => {
 		try {
 			// 1. Copy contract from data folder to taqueria project folder
 			await exec(`cp e2e/data/hello-tacos.mligo ${taqueriaProjectPath}/contracts`);
@@ -75,7 +75,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test('Verify that taqueria ligo plugin can compile one contract using compile [sourceFile] command', async () => {
+	test.skip('Verify that taqueria ligo plugin can compile one contract using compile [sourceFile] command', async () => {
 		try {
 			// 1. Copy contract from data folder to taqueria project folder
 			await exec(`cp e2e/data/hello-tacos.mligo ${taqueriaProjectPath}/contracts`);
@@ -114,7 +114,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test('Verify that taqueria ligo plugin will display proper message if user tries to compile contract that does not exist', async () => {
+	test.skip('Verify that taqueria ligo plugin will display proper message if user tries to compile contract that does not exist', async () => {
 		try {
 			// 1. Run taq compile ${contractName} for contract that does not exist
 			const { stdout, stderr } = await exec(`taq compile test.mligo`, { cwd: `./${taqueriaProjectPath}` });
@@ -129,7 +129,7 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 		}
 	});
 
-	test('Verify that taqueria ligo plugin emits error and yet displays table if contract is invalid', async () => {
+	test.skip('Verify that taqueria ligo plugin emits error and yet displays table if contract is invalid', async () => {
 		try {
 			await exec(`cp e2e/data/invalid-contract.mligo ${taqueriaProjectPath}/contracts`);
 			await exec(`taq add-contract invalid-contract.mligo`, { cwd: `./${taqueriaProjectPath}` });
@@ -138,6 +138,46 @@ describe('E2E Testing for taqueria ligo plugin', () => {
 
 			expect(stdout).toBe(contents.compileInvalid);
 			expect(stderr).toContain('File "contracts/invalid-contract.mligo", line 1, characters 23-27');
+		} catch (error) {
+			throw new Error(`error: ${error}`);
+		}
+	});
+
+	// TODO:
+	test('Verify that taqueria ligo plugin can run ligo test using taq test <sourceFile> command', async () => {
+		try {
+			// 1. Copy contract  and tests files from data folder to taqueria project folder
+			await exec(`cp e2e/data/hello-tacos.mligo ${taqueriaProjectPath}/contracts`);
+			await exec(`cp e2e/data/hello-tacos-tests.mligo ${taqueriaProjectPath}/contracts`);
+
+			// 2. Run taq test ${testFileName}
+			const { stdout, stderr } = await exec(`taq test hello-tacos-tests.mligo`, { cwd: `./${taqueriaProjectPath}` });
+			console.log(stdout);
+		} catch (error) {
+			throw new Error(`error: ${error}`);
+		}
+	});
+
+	// TODO:
+	test('Verify that taqueria ligo plugin will output proper error message running taq test <sourceFile> command against invalid test file', async () => {
+		try {
+			// 1. Copy contract  and tests files from data folder to taqueria project folder
+			await exec(`cp e2e/data/hello-tacos--invalid-tests.mligo ${taqueriaProjectPath}/contracts`);
+
+			// 2. Run taq test ${testFileName}
+			// const output =   await exec(`taq test hello-tacos-invalid-tests.mligo`, { cwd: `./${taqueriaProjectPath}` });
+			console.log(await exec(`taq test hello-tacos-invalid-tests.mligo`, { cwd: `./${taqueriaProjectPath}` }));
+		} catch (error) {
+			throw new Error(`error: ${error}`);
+		}
+	});
+
+	// TODO:
+	test('Verify that taqueria ligo plugin will output proper error message running taq test <sourceFile> command against non-existing file', async () => {
+		try {
+			// 1. Run taq test ${testFileName} against file that does not exist
+			const { stdout, stderr } = await exec(`taq test hello-tacos-tests.mligo`, { cwd: `./${taqueriaProjectPath}` });
+			console.log(stderr);
 		} catch (error) {
 			throw new Error(`error: ${error}`);
 		}

--- a/tests/e2e/taqueria-plugin-multiple-test-plugins.spec.ts
+++ b/tests/e2e/taqueria-plugin-multiple-test-plugins.spec.ts
@@ -1,0 +1,68 @@
+import { exec as exec1 } from 'child_process';
+import { createHash } from 'crypto';
+import fsPromises from 'fs/promises';
+import path from 'path';
+import util from 'util';
+import * as contents from './data/help-contents/ligo-contents';
+import { checkFolderExistsWithTimeout, generateTestProject } from './utils/utils';
+const exec = util.promisify(exec1);
+
+const taqueriaProjectPath = 'e2e/auto-test-multi-test-plugins';
+
+describe('E2E Testing for taqueria ligo plugin', () => {
+	beforeAll(async () => {
+		await generateTestProject(taqueriaProjectPath, ['ligo', 'jest']);
+		// TODO: This can removed after this is resolved:
+		// https://github.com/ecadlabs/taqueria/issues/528
+		try {
+			await exec(`taq -p ${taqueriaProjectPath}`);
+		} catch (_) {}
+	});
+
+	test('Verify that --plugin required to', async () => {
+		try {
+			// 1. Copy contract and tests files from data folder to taqueria project folder
+			await exec(`cp e2e/data/hello-tacos.mligo ${taqueriaProjectPath}/contracts`);
+			await exec(`cp e2e/data/hello-tacos-tests.mligo ${taqueriaProjectPath}/contracts`);
+
+			// 2. Run taq test ${testFileName}
+			await exec(`taq test hello-tacos-tests.mligo`, { cwd: `./${taqueriaProjectPath}` });
+		} catch (error) {
+			expect(String(error)).toContain('Missing required argument: plugin');
+		}
+	});
+
+	test('Verify that taqueria ligo plugin can run ligo test using taq test <sourceFile> command adding --plugin ligo to the command', async () => {
+		try {
+			// 2. Run taq test ${testFileName} with --plugin parameter
+			const { stdout, stderr } = await exec(`taq test hello-tacos-tests.mligo --plugin ligo`, {
+				cwd: `./${taqueriaProjectPath}`,
+			});
+			expect(stdout).toContain('All tests passed');
+		} catch (error) {
+			throw new Error(`error: ${error}`);
+		}
+	});
+
+	// Remove all files from artifacts folder without removing folder itself
+	afterEach(async () => {
+		try {
+			const files = await fsPromises.readdir(`${taqueriaProjectPath}/artifacts/`);
+			for (const file of files) {
+				await fsPromises.rm(path.join(`${taqueriaProjectPath}/artifacts/`, file));
+			}
+		} catch (error) {
+			throw new Error(`error: ${error}`);
+		}
+	});
+
+	// Clean up process to remove taquified project folder
+	// Comment if need to debug
+	afterAll(async () => {
+		try {
+			fsPromises.rm(taqueriaProjectPath, { recursive: true });
+		} catch (error) {
+			throw new Error(`error: ${error}`);
+		}
+	});
+});


### PR DESCRIPTION
# 🏗️ PR ➾

Fixes #1166 

## 🪂 Pre-Merge Checklist

- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🦀 Automated tests have been written and added to this PR
- [x] 🤿 Corresponding changes have been made to all documentation
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [x] 🏄‍♂️ Myself and others have built this branch and done manual testing on the change
- [x] ⛵ A summary describing the change has been written for release notes

----------------------------------------------------------------------------------------------------------------------------

## 🪁 Description

This PR adds a new task from the LIGO plugin called `test`, which allows LIGO devs to test their LIGO code natively. This facilitate unit tests and e2e tests for contracts.

Command syntax: `taq test <sourceFile>`

Variable names that are prefixed with `test` will be included in the tests (this comes from LIGO).

Normally, you would have a `counter.mligo` contract and `testCounter.mligo` file that tests `counter.mligo` where at the beginning of `testCounter.mligo`, you have the line `#include "counter.mligo"`.

For example (first is `counter.mligo` and second is `testCounter.mligo`):
```
type storage = int

type parameter =
  Increment of int
| Decrement of int
| Reset

let param: parameter = Increment 15

type return = operation list * storage

// Two entrypoints

let add (store, delta : storage * int) : storage = store + delta
let sub (store, delta : storage * int) : storage = store - delta

(* Main access point that dispatches to the entrypoints according to
   the smart contract parameter. *)
   
let main (action, store : parameter * storage) : return =
 ([] : operation list),    // No operations
 (match action with
   Increment (n) -> add (store, n)
 | Decrement (n) -> sub (store, n)
 | Reset         -> 0)
```

```
#include "counter.mligo"

let initial_storage = 42

let test_initial_storage =
 let (taddr, _, _) = Test.originate main initial_storage 0tez in
 assert (Test.get_storage taddr = initial_storage)

let test_increment =
 let (taddr, _, _) = Test.originate main initial_storage 0tez in
 let contr = Test.to_contract taddr in
 let _ = Test.transfer_to_contract_exn contr (Increment 1) 1mutez in
 assert (Test.get_storage taddr = initial_storage + 1)
```

## 🎢 Test Plan

Please describe the testing strategy for this change

----------------------------------------------------------------------------------------------------------------------------

### 🛸 Type of Change

- [ ] 🐟 Minor change (non-breaking change of very limited scope)
- [ ] 🦑 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🌊 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🐳 Major refactor (breaking changes and significant impact to the codebase)

----------------------------------------------------------------------------------------------------------------------------
