### PR TITLE
chore: remove docs husky hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,12 +3,6 @@
 
 npx lint-staged
 
-## Process documentation files and add modified files to the git commit
-echo "Processing documentation files..."
-npx ts-node ./parse-readme-template.ts
-echo "Adding any modified doc files to the commit"
-HUSKY=0 git ls-files **/*.md **/*.mdx --others --exclude-standard --modified | xargs git add
-
 # Update deno-lock file for CICD caching, only when CLI sourcecode changes
 npx with-staged '*.ts' 'taqueria-utils' 'taqueria-protocol' 'import-map.json' -- npm run update-lock
 HUSKY=0 git add ./deno-lock.json


### PR DESCRIPTION
# 🏗️ PR ➾ chore: remove docs husky hook

----------------------------------------------------------------------------------------------------------------------------

## 🪁 Description

Remove the husky commit hook that will generate docs using eta templates and commit them without the user knowing. This could be added as a manual job with documentation that informs the developer on how to change the docs.

## 🎢 Test Plan

- [x] Make sure that husky does not commit doc files

----------------------------------------------------------------------------------------------------------------------------

### 🛸 Type of Change

- [x] 🐟 Minor change (non-breaking change of very limited scope)

----------------------------------------------------------------------------------------------------------------------------
