### PR TITLE
fix(ci): added docker build before tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,6 +282,9 @@ jobs:
           chmod +x taq
           echo "$(pwd)" >> $GITHUB_PATH
 
+      - name: Build docker image
+        run: npm run build-docker --workspaces --if-present
+
       - name: Run unit tests
         run: npm run test:unit -w tests
 


### PR DESCRIPTION
## 🪂 Pre-Merge Checklist (Definition of Done)

## 🪁 Description

Some tests are failing because the docker image is not being built before the tests. This is a temporary fix to add a docker build step before the test run. The more permanent solution is that the docker image should be cached

### 🛸 Type of Change

- [x] 🛠️ Fix ➾ ci: added docker build tbefore tests
----------------------------------------------------------------------------------------------------------------------------
