### PR TITLE
chore: prevent vsix publishing on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -337,12 +337,12 @@ jobs:
       - name: Publish for prerelease
         if:  ${{ github.event.release.prerelease && github.event.action != 'published' && startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          npm publish --workspace=$GIT_WORKSPACE --tag 'next' --access public
+          npm publish --workspaces --tag 'next' --access public
       
       - name: Publish for official release
         if: ${{ !github.event.release.prerelease && github.event.action == 'published' }}
         run: |
-          npm publish --workspace=$GIT_WORKSPACE --tag 'latest' --access public
+          npm publish --workspaces --tag 'latest' --access public
   
   vscode-extension-workflow:
     needs: 

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -98,6 +98,7 @@ jobs:
 
   publish-marketplace:
     name: Publish VSCode Extension
+    if: ${{ github.event_name != 'pull_request' }}
     needs:
       - test-build
     runs-on: ubuntu-latest


### PR DESCRIPTION
# 🌮🌮🌮 Taqueria PR 🌮🌮🌮

## 🪁 Description

The VSCode publish job is being run for pull requests. This should not be the case and this PR aims to change that