### PR TITLE
🛠️ Fix ➾ Update Flextesa Docker Image to Latest Version

### DIFF
--- a/taqueria-flextesa-manager/Dockerfile
+++ b/taqueria-flextesa-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM oxheadalpha/flextesa:20220510
+FROM oxheadalpha/flextesa:20221026
 RUN mkdir /app
 WORKDIR /app
 COPY index.js /app/


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Updates the flextesa docker image to `oxheadalpha/flextesa:20221026`, the current latest release

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏖️ New and existing unit tests pass locally and in CI

## 🎢 Test Plan

Green pipeline 

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
