### PR TITLE
Remove default from Zod schema for env field

### DIFF
--- a/taqueria-protocol/SanitizedArgs.ts
+++ b/taqueria-protocol/SanitizedArgs.ts
@@ -44,8 +44,7 @@ export const rawSchema = z.object({
 		z.boolean().optional(),
 	),
 	plugin: z.string().min(1).optional(),
-	env: z.union([z.literal('production'), z.literal('testing'), z.literal('development'), z.string().nonempty()])
-		.default('development'),
+	env: z.string().optional(),
 	quickstart: z.string().min(1).optional(),
 	setBuild: z.preprocess(
 		val => String(val),


### PR DESCRIPTION
# 🌮 Taqueria PR

Fixes #1223

## 🪁 Description

A Zod schema had given a default to env so that if we don't specify `--env` in the CLI, it is always set to 'development', never honouring the default environment set in the config file.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

_Please include a summary of the changes to the codebase._ _Please also include relevant motivation and context for the change_
_(e.g. what was the existing behaviour, why did it break, etc.)_

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
