### PR TITLE
🛠️ Fix ➾ (build) removed caching for build-docker

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,6 @@
 			"options": {
 				"cacheableOperations": [
 					"build-package",
-					"build-docker",
 					"build",
 					"test:unit",
 					"test:integration",
@@ -18,11 +17,6 @@
 		"build-package": {
 			"dependsOn": [
 				"^build-package"
-			]
-		},
-		"build-docker": {
-			"dependsOn": [
-				"^build-docker"
 			]
 		},
 		"build": {


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

NX is configured to cache a number of tasks including  `build:docker`. This is causing issues with outdated Docker images when switching branches and running `build:docker` which seems to not generate the correct Docker image for the branch.

This PR disables caching for `build:docker` to ensure  new Docker images are always generated 

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [x] 🛠️ Fix ➾

