### PR TITLE
Reintroduce maxWorker=1 for E2E Jest tests

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -7,8 +7,8 @@ if [ "$0" == "./bin/build-all.sh" ] && [ -f index.ts ]; then
     echo ""
     echo '**********************************************'
     echo "** Installing NPM dependencies"
-    npm clean-install
-    npm run bootstrap -- --force-local
+    npm ci
+    npm run bootstrap
 
     echo ""
     echo '**********************************************'

--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -7,8 +7,8 @@ if [ "$0" == "./bin/build-all.sh" ] && [ -f index.ts ]; then
     echo ""
     echo '**********************************************'
     echo "** Installing NPM dependencies"
-    npm install
-    npm run bootstrap
+    npm clean-install
+    npm run bootstrap -- --force-local
 
     echo ""
     echo '**********************************************'

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,7 @@
 		"test:unit:deno:with-coverage": "TEST=true deno test unit/ --allow-all --unstable --coverage=coverage_report && deno coverage coverage_report && deno coverage coverage_report --lcov > coverage_profile.lcov",
 		"test:unit:selected": "TEST=true deno test unit/taqueria-utils/taqueria-utils.test.ts --allow-all --unstable --coverage=coverage_report && deno coverage coverage_report",
 		"test:integration": "TEST=true jest --config jest.config.integration.ts --no-cache",
-		"test:e2e": "TEST=true jest --config jest.config.e2e.ts"
+		"test:e2e": "TEST=true jest --config jest.config.e2e.ts --maxWorkers=1"
 	},
 	"repository": {
 		"type": "git",

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,7 @@
 		"test:unit:deno:with-coverage": "TEST=true deno test unit/ --allow-all --unstable --coverage=coverage_report && deno coverage coverage_report && deno coverage coverage_report --lcov > coverage_profile.lcov",
 		"test:unit:selected": "TEST=true deno test unit/taqueria-utils/taqueria-utils.test.ts --allow-all --unstable --coverage=coverage_report && deno coverage coverage_report",
 		"test:integration": "TEST=true jest --config jest.config.integration.ts --no-cache",
-		"test:e2e": "TEST=true jest --config jest.config.e2e.ts --maxWorkers=1"
+		"test:e2e": "TEST=true jest --config jest.config.e2e.ts --maxWorkers=2"
 	},
 	"repository": {
 		"type": "git",

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,7 @@
 		"test:unit:deno:with-coverage": "TEST=true deno test unit/ --allow-all --unstable --coverage=coverage_report && deno coverage coverage_report && deno coverage coverage_report --lcov > coverage_profile.lcov",
 		"test:unit:selected": "TEST=true deno test unit/taqueria-utils/taqueria-utils.test.ts --allow-all --unstable --coverage=coverage_report && deno coverage coverage_report",
 		"test:integration": "TEST=true jest --config jest.config.integration.ts --no-cache",
-		"test:e2e": "TEST=true jest --config jest.config.e2e.ts --maxWorkers=2"
+		"test:e2e": "TEST=true jest --config jest.config.e2e.ts --maxWorkers=1"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Reintroduce `maxWorker=1` to the E2E Jest tests. This fixes E2E tests failing on mac runners. Failed job example

https://github.com/ecadlabs/taqueria/actions/runs/3517074829/jobs/5896661542

