### PR TITLE
Don't log scaffold.json contents when scaffolding

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -430,7 +430,6 @@ const runScaffoldPostInit = (scaffoldDir: SanitizedAbsPath.t): Future<TaqError.t
 	const scaffoldConfigAbspath = SanitizedAbsPath.create(`${scaffoldDir}/scaffold.json`);
 	return pipe(
 		readJsonFile<ScaffoldConfig.t>(scaffoldConfigAbspath),
-		map(logInput('Scaffold Config')),
 		coalesce(_ => ({}) as ScaffoldConfig.t)(identity),
 		chain(scaffoldConfig =>
 			typeof scaffoldConfig === 'object' && scaffoldConfig.postInit


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Removing left-over debugging statement, which outputs the contents of the scaffold.json file:

```
{
    "postInit": "npm run setup"
}
```

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

_Please include a summary of the changes to the codebase._ _Please also include relevant motivation and context for the change_
_(e.g. what was the existing behaviour, why did it break, etc.)_

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [ ] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
