### PR TITLE
🛠️ Fix ➾ Set TAQ_VERSION and BUILD in one script to unify CI and local build and test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           npx lerna bootstrap 
           npm run build:packages 
-          npm run build:binary
+          ./bin/build.sh
           npm run build:docker
 
       - name: Run unit tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,6 @@ concurrency:
   group: ${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
-env:
-  TAQ_VERSION: ${{ github.ref_name }}
-
 jobs:
   # When we use reusable we lose the ability to to filter out the workflow for changes to certain paths.
   # This job creates boolean outputs based on path filters. These outputs can then be used as job conditions
@@ -102,9 +99,7 @@ jobs:
         env:
           DENO_DIR: "./deno"
         run: |
-          BUILD=`git rev-parse --short "$GITHUB_SHA"`
-          TAQ_VERSION="${TAQ_VERSION/\//-}"
-          deno compile --output taq --allow-run --allow-write --allow-read --allow-env --allow-net --import-map ./import_map.json --no-prompt --target $DENO_TARGET index.ts --setBuild "$BUILD" --setVersion "$TAQ_VERSION" --lock ./deno-lock.json
+          npm run build:binary
           ./"${{ matrix.taqueria_bin }}" init -p ./test_project
           if [ ! -f ./test_project/.taq/config.json ]; then
             echo "Project not initialized"
@@ -213,11 +208,9 @@ jobs:
 
       - name: Build all
         run: |
-          BUILD=`git rev-parse --short "$GITHUB_SHA"`
-          TAQ_VERSION="${TAQ_VERSION/\//-}"
           npx lerna bootstrap 
           npm run build:packages 
-          deno compile --output taq --allow-run --allow-write --allow-read --allow-env --allow-net --import-map ./import_map.json --no-prompt index.ts --setBuild "$BUILD" --setVersion "$TAQ_VERSION" --lock ./deno-lock.json
+          npm run build:binary
           npm run build:docker
 
       - name: Run unit tests
@@ -277,12 +270,8 @@ jobs:
 
       - name: Build all
         run: |
-          BUILD=`git rev-parse --short "$GITHUB_SHA"`
-          TAQ_VERSION="${TAQ_VERSION/\//-}"
           npx lerna bootstrap 
           npm run build:packages 
-          deno compile --output taq --allow-run --allow-write --allow-read --allow-env --allow-net --import-map ./import_map.json --no-prompt index.ts --quickstart "`cat quickstart.md`" --setBuild "$BUILD" --setVersion "$TAQ_VERSION" --lock ./deno-lock.json
-          npm run build:docker
 
       - name: Publish for PR
         if:  ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           DENO_DIR: "./deno"
         run: |
-          npm run build:binary
+          ./bin/build.sh
           ./"${{ matrix.taqueria_bin }}" init -p ./test_project
           if [ ! -f ./test_project/.taq/config.json ]; then
             echo "Project not initialized"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -7,7 +7,12 @@ if [ "$0" == "./bin/build.sh" -a -f index.ts ]; then
         echo "Please install deno before attempting to build."
         echo "Run: curl -fsSL https://deno.land/install.sh | sh"
     else
-        DENO_DIR=./deno deno compile -o taq --allow-run --allow-write --allow-read --allow-env --allow-net --import-map ./import_map.json --no-prompt index.ts --setBuild "$BUILD" --setVersion "$TAQ_VERSION" --lock ./deno-lock.json
+        if [  -z "$DENO_TARGET" ]; then
+            TARGET_ARG=""
+        else
+            TARGET_ARG="--target $DENO_TARGET"
+        fi
+        DENO_DIR=./deno deno compile -o taq --allow-run --allow-write --allow-read --allow-env --allow-net --import-map ./import_map.json --no-prompt index.ts --setBuild "$BUILD" --setVersion "$TAQ_VERSION" --lock ./deno-lock.json $TARGET_ARG
     fi
 else
     echo "Usage: ./bin/build.sh"

--- a/bin/debug.sh
+++ b/bin/debug.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-BRANCH=`git branch --show-current`
-TAQ_VERSION="dev:$BRANCH"
-TIMESTAMP=`date +%s`
-BUILD="${BRANCH}-${TIMESTAMP}"
+source ./bin/set-vars.sh
+
 BIN_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 PROJ_DIR="${BIN_DIR}/.."
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-BRANCH=`git branch --show-current`
-TAQ_VERSION="dev:$BRANCH"
-TIMESTAMP=`date +%s`
-BUILD="${BRANCH}-${TIMESTAMP}"
+source ./bin/set-vars.sh
+
 BIN_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 PROJ_DIR="${BIN_DIR}/.."
 

--- a/bin/set-vars.sh
+++ b/bin/set-vars.sh
@@ -4,7 +4,7 @@ COMMIT=`git rev-parse --short HEAD`
 if [  -z "$GITHUB_REF_NAME" ]; then
     TAQ_VERSION="dev-${BRANCH//\//-}"
 else
-    TAQ_VERSION="${GITHUB_REF_NAME//\//-}"
+    TAQ_VERSION="${BRANCH//\//-}"
 fi
 TIMESTAMP=`date +%s`
 BUILD="$COMMIT"

--- a/bin/set-vars.sh
+++ b/bin/set-vars.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 BRANCH=`git branch --show-current`
 COMMIT=`git rev-parse --short HEAD`
-if [  -z "$GITHUB_REF" ]; then
-    TAQ_VERSION="dev-$BRANCH"
+if [  -z "$GITHUB_REF_NAME" ]; then
+    TAQ_VERSION="dev-${BRANCH//\//-}"
 else
-    TAQ_VERSION="${GITHUB_REF##*/}"
+    TAQ_VERSION="${GITHUB_REF_NAME//\//-}"
 fi
 TIMESTAMP=`date +%s`
-if [  -z "$GITHUB_SHA" ]; then
-    BUILD="$COMMIT"
-else
-    BUILD="${GITHUB_SHA:0:8}"
-fi
+BUILD="$COMMIT"

--- a/bin/set-vars.sh
+++ b/bin/set-vars.sh
@@ -4,7 +4,7 @@ COMMIT=`git rev-parse --short HEAD`
 if [  -z "$GITHUB_REF_NAME" ]; then
     TAQ_VERSION="dev-${BRANCH//\//-}"
 else
-    TAQ_VERSION="${BRANCH//\//-}"
+    TAQ_VERSION="${GITHUB_REF_NAME//\//-}"
 fi
 TIMESTAMP=`date +%s`
 BUILD="$COMMIT"

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-ali="refs/pull/1123/merge"
-echo "${ali##*/}"
-echo "${ali//\//-}"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ali="refs/pull/1123/merge"
+echo "${ali##*/}"
+echo "${ali//\//-}"


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

After the previous changes to the build and CI, we still had failures. We decided to centralize the calculation of TAQ_VERSION and BUILD in once place. This will make it easier to change in the future, and will make it easier to debug if things go wrong.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Removed all calculation of TAQ_VERSION and BUILD variables from `.github/workflows/main.yml` and moved all to `bin/set-vars.sh` which is sourced before all build and test actions.

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾ Unify calculation of TAQ_VERSION and BUILD in `bin/set-vars.sh`
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
