### PR TITLE
Fixes #1363, Adds import-map to test:unit:deno:debug task

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,7 @@
 		"test:unit:deno": "../bin/before-all-tests.sh && TEST=true deno test unit/ --allow-all --unstable --import-map ../import_map.json",
 		"test:unit:jest": "../bin/before-all-tests.sh && TEST=true jest --config jest.config.unit.ts --no-cache",
 		"test:unit:jest:debug": "../bin/before-all-tests.sh && TEST=true jest --config jest.config.unit.ts --no-cache --detectOpenHandles --detectLeaks",
-		"test:unit:deno:debug": "../bin/before-all-tests.sh && TEST=true deno test unit/ --allow-all --unstable --inspect-brk",
+		"test:unit:deno:debug": "../bin/before-all-tests.sh && TEST=true deno test unit/ --allow-all --unstable --import-map ../import_map.json",
 		"test:unit:deno:with-coverage": "../bin/before-all-tests.sh && TEST=true deno test unit/ --allow-all --unstable --coverage=coverage_report && deno coverage coverage_report && deno coverage coverage_report --lcov > coverage_profile.lcov",
 		"test:unit:selected": "../bin/before-all-tests.sh && TEST=true deno test unit/taqueria-utils/taqueria-utils.test.ts --allow-all --unstable --coverage=coverage_report && deno coverage coverage_report",
 		"test:integration": "../bin/before-all-tests.sh && TEST=true jest --config jest.config.integration.ts --no-cache",


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

When running test:unit:deno:debug, there needs to be an import-map specified.

See https://github.com/ecadlabs/taqueria/issues/1563

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Added the import-map option to the `deno test` command.

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [ ] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
