### PR TITLE
🛠️ Fix ➾ Prevent running compile current file command if the text editor is not focused

### DIFF
--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -239,7 +239,7 @@
 				"category": "Taqueria",
 				"title": "Compile Current File",
 				"shortTitle": "compile current file",
-				"enablement": "resourceExtname in @taqueria/supported-smart-contract-extensions",
+				"enablement": "resourceExtname in @taqueria/supported-smart-contract-extensions && editorFocus",
 				"icon": "$(combine)"
 			},
 			{

--- a/taqueria-vscode-extension/src/lib/helpers.ts
+++ b/taqueria-vscode-extension/src/lib/helpers.ts
@@ -1105,6 +1105,15 @@ export class VsCodeHelper {
 			}
 		}
 		if (fileSelectionBehavior === 'currentFile') {
+			let viewColumn = this.vscode.window.activeTextEditor?.viewColumn;
+			if (!viewColumn) {
+				this.logHelper.showLog(
+					OutputLevels.warn,
+					`Focused window is not a text editor.`,
+				);
+				return;
+			}
+
 			let absoluteFilePath = this.vscode.window.activeTextEditor?.document.uri.path;
 			if (!absoluteFilePath) {
 				this.logHelper.showLog(


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

This PR prevents running "Compile Current File" command when the text editor is not focused (e.g. clicked on the Taqueria output panel).

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [x] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

_Please include a summary of the changes to the codebase._ _Please also include relevant motivation and context for the change_
_(e.g. what was the existing behaviour, why did it break, etc.)_

This PR adds a runtime check so that the "Compile Current File" command is not executed when the text editor is not focused for any reason.

It also adds a condition for TVsCE `enablement` so that the command is displayed in the command palette only if the text editor has focus.

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

1. Open taquified workspace with extension enabled.
2. Open contract source file (e.g. ligo one).
3. Open command palette and type "compile".
4. It should display "Compile Current File" command
5. Run the command
6. It should properly compile the contract
7. Open contract source file (e.g. ligo one).
8. Click on the "Output" secondary sidebar panel.
9. The command  "Compile Current File" should not be available.

![image](https://user-images.githubusercontent.com/10618781/205340778-bddc045a-5a26-4df6-abff-63094e89a30d.png)

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
