### PR TITLE
Open Contracts and Artifacts when double-clicking a TreeViewItem in Taqueria sidebar

### DIFF
--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -239,7 +239,7 @@
 				"category": "Taqueria",
 				"title": "Compile Current File",
 				"shortTitle": "compile current file",
-				"enablement": "resourceExtname in @taqueria/supported-smart-contract-extensions",
+				"enablement": "resourceExtname in @taqueria/supported-smart-contract-extensions && editorFocus",
 				"icon": "$(combine)"
 			},
 			{

--- a/taqueria-vscode-extension/src/lib/gui/ArtifactsDataProvider.ts
+++ b/taqueria-vscode-extension/src/lib/gui/ArtifactsDataProvider.ts
@@ -16,18 +16,22 @@ export class ArtifactsDataProvider extends TaqueriaDataProviderBase
 	}
 
 	async getChildren(element?: ArtifactTreeItem): Promise<ArtifactTreeItem[]> {
-		const mainFolder = this.helper.getMainWorkspaceFolder();
-		if (!mainFolder) {
+		if (element) {
 			return [];
 		}
-		const config = await Util.TaqifiedDir.create(mainFolder.path as Util.PathToDir, this.helper.i18n);
+		const { config, mainFolder } = await this.getConfig();
+		if (!config || !mainFolder) {
+			return [];
+		}
 		const artifactsFolder = config.config.artifactsDir ?? 'artifacts';
 		const artifacts = await vscode.workspace.findFiles(`${artifactsFolder}/**/*.tz`, '**/node_modules/**');
 		artifacts.sort();
 		const treeItems = artifacts.map(uri =>
 			new ArtifactTreeItem(
-				mainFolder ? path.relative(path.join(mainFolder.path, artifactsFolder), uri.path) : path.basename(uri.path),
+				uri,
 				vscode.TreeItemCollapsibleState.None,
+				artifactsFolder,
+				mainFolder,
 			)
 		);
 		return treeItems;
@@ -46,11 +50,22 @@ export class ArtifactsDataProvider extends TaqueriaDataProviderBase
 }
 
 export class ArtifactTreeItem extends vscode.TreeItem implements HasFileName {
+	fileName: string;
 	constructor(
-		public readonly fileName: string,
+		public readonly artifactUri: vscode.Uri,
 		readonly collapsibleState: vscode.TreeItemCollapsibleState,
+		readonly artifactsFolder: string,
+		readonly mainFolder: vscode.Uri,
 	) {
+		const fileName = path.relative(path.join(mainFolder.path, artifactsFolder), artifactUri.path);
 		super(fileName, collapsibleState);
-		this.tooltip = `${fileName}`;
+		this.fileName = fileName;
+		this.tooltip = `${this.fileName}`;
+		this.command = {
+			command: 'vscode.open',
+			title: 'Open Artifact for Editing',
+			arguments: [artifactUri],
+			tooltip: 'Open Artifact for Editing',
+		};
 	}
 }

--- a/taqueria-vscode-extension/src/lib/gui/TaqueriaDataProviderBase.ts
+++ b/taqueria-vscode-extension/src/lib/gui/TaqueriaDataProviderBase.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { VsCodeHelper } from '../helpers';
 import * as Util from '../pure';
 
@@ -6,12 +7,15 @@ export class TaqueriaDataProviderBase {
 		protected helper: VsCodeHelper,
 	) {}
 
-	async getConfig(): Promise<{ config: Util.TaqifiedDir | null; pathToDir: Util.PathToDir | null }> {
+	async getConfig(): Promise<
+		{ config: Util.TaqifiedDir | null; pathToDir: Util.PathToDir | null; mainFolder: vscode.Uri | undefined }
+	> {
 		const mainFolder = this.helper.getMainWorkspaceFolder();
 		if (!mainFolder) {
 			return {
 				pathToDir: null,
 				config: null,
+				mainFolder,
 			};
 		} else {
 			try {
@@ -20,12 +24,14 @@ export class TaqueriaDataProviderBase {
 				return {
 					config,
 					pathToDir,
+					mainFolder,
 				};
 			} catch (e: any) {
 				await this.helper.notifyAndLogError('Error while loading config, sandboxes list will fail to populate', e);
 				return {
 					pathToDir: null,
 					config: null,
+					mainFolder,
 				};
 			}
 		}

--- a/taqueria-vscode-extension/src/lib/helpers.ts
+++ b/taqueria-vscode-extension/src/lib/helpers.ts
@@ -1106,6 +1106,15 @@ export class VsCodeHelper {
 			}
 		}
 		if (fileSelectionBehavior === 'currentFile') {
+			let viewColumn = this.vscode.window.activeTextEditor?.viewColumn;
+			if (!viewColumn) {
+				this.logHelper.showLog(
+					OutputLevels.warn,
+					`Focused window is not a text editor.`,
+				);
+				return;
+			}
+
 			let absoluteFilePath = this.vscode.window.activeTextEditor?.document.uri.path;
 			if (!absoluteFilePath) {
 				this.logHelper.showLog(


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

We can see the contracts and artifacts in the sidebar, but clicking on them did not open them in the editor.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Now clicking on contracts and artifacts in the sidebar opens them in the text editor

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [ ] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
