### PR TITLE
Fix: Change Container Name in VsCode Extension to Match Flextesa Plugin

### DIFF
--- a/taqueria-plugin-flextesa/proxy.ts
+++ b/taqueria-plugin-flextesa/proxy.ts
@@ -30,6 +30,8 @@ const ECAD_FLEXTESA_IMAGE_ENV_VAR = 'TAQ_ECAD_FLEXTESA_IMAGE';
 
 const getDefaultDockerImage = (opts: Opts) => `ghcr.io/ecadlabs/taqueria-flextesa:${opts.setVersion}-${opts.setBuild}`;
 
+// ATTENTION: There is a duplicate of this function in taqueria-vscode-extension/src/lib/gui/SandboxesDataProvider.ts
+// Please make sure the two are kept in-sync
 export const getUniqueSandboxName = async (sandboxName: string, projectDir: string) => {
 	const hash = await stringToSHA256(sandboxName + projectDir);
 	return `${sandboxName.substring(0, 10)}-${hash.substring(0, 5)}`;

--- a/taqueria-vscode-extension/src/lib/gui/SandboxesDataProvider.ts
+++ b/taqueria-vscode-extension/src/lib/gui/SandboxesDataProvider.ts
@@ -1,5 +1,6 @@
 import { toSHA256 } from '@taqueria/protocol/SHA256';
 import fetch from 'node-fetch-commonjs';
+import path from 'path';
 import * as vscode from 'vscode';
 import { HasRefresh, mapAsync, VsCodeHelper } from '../helpers';
 import { OutputLevels } from '../LogHelper';
@@ -365,7 +366,7 @@ export class SandboxesDataProvider extends TaqueriaDataProviderBase
 	// taqueria-plugin-flextesa/proxy.ts. As suggested in https://github.com/ecadlabs/taqueria/issues/1030, we need to
 	// take care of this tech debt.
 	private async getUniqueSandboxName(sandboxName: string, projectDir: string) {
-		const hash = await toSHA256(projectDir);
+		const hash = await toSHA256(sandboxName + projectDir);
 		return `${sandboxName.substring(0, 10)}-${hash.substring(0, 5)}`;
 	}
 


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

A previous change in how the Flextesa Plugin names its containers was not reflected in the VsCode Extension

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Updated the container names that the VsCode Extension is looking for. Also added a comment to the function in Flextesa plugin to remind synchronizing the other one.

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾ Change Container Name in VsCode Extension to Match Flextesa Plugin
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
