### PR TITLE
Check for deno version

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -29,7 +29,7 @@ if [ "$0" == "./bin/build-all.sh" ] && [ -f index.ts ]; then
         fi
     else
         echo "❌ Deno is not installed."
-        echo -2
+        exit -2
     fi
     echo "** Dependency checks passed"
 

--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -18,6 +18,19 @@ if [ "$0" == "./bin/build-all.sh" ] && [ -f index.ts ]; then
         echo "❌ Docker is not installed, not running, or the user needs permission."
         exit $errorCode
     fi
+    if [ -n `which deno || ""` ]; then
+        deno --version | grep 1.23 >/dev/null
+        errorCode=$?
+        if [ $errorCode -ne 0 ]; then
+            echo "❌ Deno is installed, but not using v1.23.x. Please use Deno v1.23.x."
+            exit $errorCode
+        else
+            echo "✅ Deno is installed, and running v1.23.x"
+        fi
+    else
+        echo "❌ Deno is not installed."
+        echo -2
+    fi
     echo "** Dependency checks passed"
 
     set -e # exiting on error

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -7,6 +7,13 @@ if [ "$0" == "./bin/build.sh" -a -f index.ts ]; then
         echo "Please install deno before attempting to build."
         echo "Run: curl -fsSL https://deno.land/install.sh | sh"
     else
+        deno --version | grep 1.23 >/dev/null
+        errorCode=$?
+        if [ $errorCode -ne 0 ]; then
+            echo "Deno is installed, but not using v1.23.x."
+            exit $errorCode
+        fi
+
         if [  -z "$DENO_TARGET" ]; then
             TARGET_ARG=""
         else


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Taqueria requires Deno v1.23.X to build. This branch adjusts the build.sh and build-all.sh scripts to ensure that Deno is installed and set to the correct version.

*NOTE:  I've set the target for this PR to prerelease-0.25.0 so that you only see the actual files changed in this PR*

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] 🔱 The test plan has been implemented and verified by an SDET
- [x] 🐚 Required changes to the VScE have been made
- [x] 🪸 Required updates to scaffolds have been made
- [x] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Modified build.sh and build-all.sh scripts. 

## 🎢 Test Plan

I've tested that if I have Deno v1.24 installed I'll get an error when running `npm run build-all`. I've also verified that the error goes away when I have v1.23 installed.

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
