### PR TITLE
🧽 Chore ➾ Stop building native Windows binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,10 +65,6 @@ jobs:
            os_short: ubuntu
            deno_target: "x86_64-unknown-linux-gnu"
            taqueria_bin: "taq"
-         - os: windows-latest
-           os_short: windows
-           deno_target: "x86_64-pc-windows-msvc"
-           taqueria_bin: "taq.exe"
          - os: macOS-latest
            os_short: macos
            deno_target: "x86_64-apple-darwin"
@@ -76,7 +72,6 @@ jobs:
 
     outputs:
       public-url-ubuntu: ${{ steps.public-url.outputs.ubuntu }}
-      public-url-windows: ${{ steps.public-url.outputs.windows }}
       public-url-macos: ${{ steps.public-url.outputs.macos }}
 
     env:
@@ -365,7 +360,6 @@ jobs:
                       <p>
                           <a href="${{ needs.build-binaries.outputs.public-url-ubuntu }}">Linux</a><br>
                           <a href="${{ needs.build-binaries.outputs.public-url-macos }}">MacOS</a><br>
-                          <a href="${{ needs.build-binaries.outputs.public-url-windows }}">Windows</a>
                       </p>
                   </td>
                 </tr>
@@ -425,7 +419,6 @@ jobs:
         run: |
           mkdir release && cd release
           wget ${{ needs.build-binaries.outputs.public-url-ubuntu }} -O taq-linux
-          wget ${{ needs.build-binaries.outputs.public-url-windows }} -O taq-windows.exe
           wget ${{ needs.build-binaries.outputs.public-url-macos }} -O taq-macos
           wget ${{ needs.vscode-extension-workflow.outputs.vsixGcsUrl }}
 


### PR DESCRIPTION
# 🌮 Taqueria PR

References #1602

## 🪁 Description

In a team call this morning we decided to drop support for native Windows binary.

## 🛩️ Summary of Changes

Delete references to Windows in our Github workflow files

## 🎢 Test Plan

 - [ ] Github workflow should pass