### PR TITLE
🧽 Chore ➾ Downgrade Deno version to v1.23.1 in GH Workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
     uses: ./.github/workflows/vscode-extension.yml
     with:
       prerelease: ${{ needs.workflow-setup.outputs.prerelease }}
-      deno-version: "${{ env.DENO_VERSION }}"
+      deno-version: ${{ env.DENO_VERSION }}
     secrets:
       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }} 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -292,16 +292,25 @@ jobs:
         run: |
           echo ${NODE_AUTH_TOKEN} >> ~/.npmrc
           npm publish --workspaces --tag 'latest' --access public --registry $NPM_REGISTRY
-
+  
+  # Workaround for exposing env context to reusable workflows
+  # TODO: Refactor once https://github.com/orgs/community/discussions/26671 is resolved
+  expose-env-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      deno_version: ${{ env.DENO_VERSION }}
+    steps:
+      - run: echo "Exposing env.DENO_VERSION for reusable workflow"
   vscode-extension-workflow:
     needs: 
       - workflow-setup
       - publish-npm-packages
-    # if: ${{ !github.event.pull_request.head.repo.fork }}
+      - expose-env-vars
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/vscode-extension.yml
     with:
       prerelease: ${{ needs.workflow-setup.outputs.prerelease }}
-      deno-version: ${{ env.DENO_VERSION }}
+      deno-version: ${{ needs.vscode-extension.outputs.deno_version }}
     secrets:
       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }} 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -297,7 +297,7 @@ jobs:
     needs: 
       - workflow-setup
       - publish-npm-packages
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    # if: ${{ !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/vscode-extension.yml
     with:
       prerelease: ${{ needs.workflow-setup.outputs.prerelease }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
+env:
+  DENO_VERSION: '1.23.1'
+
 jobs:
   # When we use reusable we lose the ability to to filter out the workflow for changes to certain paths.
   # This job creates boolean outputs based on path filters. These outputs can then be used as job conditions
@@ -84,7 +87,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: "1.23.4"
+          deno-version: ${{ env.DENO_VERSION }}
 
       ## This job will compile the binary for the target OS. The binary is then tested by initializing a project called "test_project"
       ## If the initialization command output is equal to "Project taq'ified!" we know that the binary works for the given os, else the command exits with status code 1.
@@ -195,7 +198,7 @@ jobs:
 
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: "1.23.4"
+          deno-version: ${{ env.DENO_VERSION }}
 
       - name: Add working dir to PATH
         run: echo "$(pwd)" >> $GITHUB_PATH
@@ -298,6 +301,7 @@ jobs:
     uses: ./.github/workflows/vscode-extension.yml
     with:
       prerelease: ${{ needs.workflow-setup.outputs.prerelease }}
+      deno-version: ${{ env.DENO_VERSION }}
     secrets:
       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }} 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: ${{ env.DENO_VERSION }}
+          deno-version: "${{ env.DENO_VERSION }}"
 
       ## This job will compile the binary for the target OS. The binary is then tested by initializing a project called "test_project"
       ## If the initialization command output is equal to "Project taq'ified!" we know that the binary works for the given os, else the command exits with status code 1.
@@ -198,7 +198,7 @@ jobs:
 
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: ${{ env.DENO_VERSION }}
+          deno-version: "${{ env.DENO_VERSION }}"
 
       - name: Add working dir to PATH
         run: echo "$(pwd)" >> $GITHUB_PATH
@@ -301,7 +301,7 @@ jobs:
     uses: ./.github/workflows/vscode-extension.yml
     with:
       prerelease: ${{ needs.workflow-setup.outputs.prerelease }}
-      deno-version: ${{ env.DENO_VERSION }}
+      deno-version: "${{ env.DENO_VERSION }}"
     secrets:
       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }} 

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: ${{ inputs.deno-version }}
+          deno-version: "${{ inputs.deno-version }}"
 
       - name: Attempt to rebuild
         run: npm rebuild | true

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -6,6 +6,9 @@ on:
       prerelease:
         required: false
         type: string
+      deno-version:
+        required: true
+        type: string
     secrets:
       GCP_PROJECT:
         required: true
@@ -52,7 +55,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: "1.23.4"
+          deno-version: ${{ inputs.deno-version }}
 
       - name: Attempt to rebuild
         run: npm rebuild | true


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

We decided to downgrade Deno to version `1.23.1` for our GH workflows as this is the version used by our developers. 

I've created a global env variable for Deno version and referenced it in each job. There is an hacky workaround for exposing the env variable to reusable workflow as I was hitting the bug mentioned in https://github.com/orgs/community/discussions/26671

## 🎢 Test Plan

GH Workflows should pass
## 🛸 Type of Change

- [x] 🧽 Chore ➾
