### PR TITLE
Fix: Have TzKt.Api do more retries for Database Schema before failing

### DIFF
--- a/taqueria-plugin-flextesa/tzkt-manager.ts
+++ b/taqueria-plugin-flextesa/tzkt-manager.ts
@@ -1,15 +1,11 @@
 import { getArch, SandboxConfig } from '@taqueria/node-sdk';
-import { Config } from '@taqueria/node-sdk';
-import { Protocol } from '@taqueria/node-sdk/types';
 import { Config as RawConfig } from '@taqueria/protocol/types';
 import { getContainerName, getNewPortIfPortInUse, getUniqueSandboxName, Opts, updateConfig } from './proxy';
 
-const { Url } = Protocol;
-
 const getTzKtDockerImages = (opts: Opts) => ({
 	postgres: `postgres:14.5-alpine`,
-	sync: `alirezahaghshenas/tzkt:sync-1.10.3`,
-	api: `alirezahaghshenas/tzkt:api-1.10.3`,
+	sync: `ecadlabs/tzkt-sync:1.8.3-taqueria`,
+	api: `ecadlabs/tzkt-api:1.8.3-taqueria`,
 });
 
 export const getTzKtContainerNames = async (sandboxName: string, parsedArgs: Opts) => {
@@ -22,7 +18,6 @@ export const getTzKtContainerNames = async (sandboxName: string, parsedArgs: Opt
 };
 
 const getTzKtContainerEnvironments = async (sandboxName: string, sandbox: SandboxConfig, opts: Opts) => {
-	const sandboxPort = new URL(sandbox.rpcUrl).port;
 	const containerNames = await getTzKtContainerNames(sandboxName, opts);
 	const sandboxContainerName = await getContainerName(sandboxName, opts);
 	const connectionStringEnv =


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

When we start the Sandbox, four containers start:

- The Flextesa Sandbox
- Postgres
- TzKt.Sync that reads from the sandbox and updates postgres
- TzKt.Api that reads from postgres and serves API calls.

After starting, TzKt.sync will apply the database schema to postgres. TzKt.Api keeps checking this schema to make sure it can work with that document. It does this 30 times. This has been enough for their own setup (on a server, where they can start them separately and wait for sync to apply the schema) and on my machines.
But on some machines, this is not enough.

So here is our solution:

- On our version of TzKt we increase that to 120.
- Open a ticket on their repo to read that from settings (which can then be overriden in environment variables)
- When they merge that and release a .net 7 image, switch to their image and use the env to override this value

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [x] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

We release TzKt images in Ecad labs docker hub account and used it here

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾ Have TzKt.Api do more retries for Database Schema before failing
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
