### PR TITLE
Fix Taq check in VsCode

### DIFF
--- a/taqueria-vscode-extension/src/lib/pure.ts
+++ b/taqueria-vscode-extension/src/lib/pure.ts
@@ -4,8 +4,8 @@ import { exec, ExecException } from 'child_process';
 import { parse } from 'comment-json';
 import { readFile, stat } from 'fs/promises';
 import { join } from 'path';
-import { OutputFunction } from './helpers';
-import { OutputLevels } from './LogHelper';
+import { OutputFunction, VsCodeHelper } from './helpers';
+import { LogHelper, OutputLevels } from './LogHelper';
 import { TaqVsxError } from './TaqVsxError';
 
 /***********************************************************************/
@@ -163,8 +163,19 @@ export const execCmd = (
 		}
 	});
 
-export const checkTaqBinary = async (inputPath: PathToTaq, i18n: i18n, showOutput: OutputFunction) => {
-	const result = await execCmd(`${inputPath} testFromVsCode`, showOutput);
+export const checkTaqVersion = async (
+	inputPath: PathToTaq,
+	i18n: i18n,
+	showOutput: OutputFunction,
+	helper: VsCodeHelper,
+): Promise<string> => {
+	const result = await execCmd(`${inputPath} --version --fromVsCode`, showOutput);
+	if (result.executionError) {
+		helper.logAllNestedErrors(result.executionError);
+	}
+	if (result.standardError && result.standardError.length) {
+		showOutput(OutputLevels.error, result.standardError);
+	}
 	return result.standardOutput;
 };
 


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

The CLI check used to call `taq testFromVsCode` and depended on `OK` to be returned from that command. A PR has broken this.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [x] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Changed the logic to run `taq --version --fromVsCode` instead, so that we can show the Version as well.
The version is still not shown, as I do not know how to show it in `viesWelcome.content`. Asked the VsCode team in their slack. Once we know it, showing it should be two lines of change.

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾ Taq Check in VsCode was broken
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
