### PR TITLE
 🛠️ Fix ➾ Interpretation and parsing of boolean options given to a plugin

### DIFF
--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -233,7 +233,8 @@ const formatArgs = (args: Record<string, string>) => {
 	const entries = Object.entries(args).map(
 		([key, value]) => {
 			if (key === 'config') return [key, JSON.parse(value)];
-			if (value === 'false' || value === 'true') return [key, Boolean(value)];
+			else if (value === 'false') return [key, false];
+			else if (value === 'true') return [key, true];
 			return [key, value];
 		},
 	);


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

The taq CLI communicates with plugins by passing options as CLI arguments. In retrospect, I think passing via stdin would have been more appropriate but that's a different issue. :)

In any case, a CLI argument of `--debug 'false'` was being wrongly interpreted, such as the ParsedArgs object would have the `debug` property set to `true` instead of `false`. This PR fixes that.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Fixed the logic of the formatArgs() function in the SDK.
