### PR TITLE
✨ Feature ➾ added ability to override versions in SmartPy and fix error reporting issue during SmartPy compile and test

### DIFF
--- a/taqueria-plugin-smartpy/README.md
+++ b/taqueria-plugin-smartpy/README.md
@@ -17,6 +17,9 @@ To install the SmartPy plugin on a Taqueria project, navigate to the project fol
 taq install @taqueria/plugin-smartpy
 ```
 
+> ### :page_with_curl: Note
+> You can override the SmartPy version used by the plugin by creating the environment variable `TAQ_SMARTPY_VERSION` and setting it to your desired version. E.g. `v0.16.0`
+
 ## The `taq compile` Task
 
 Basic usage is:

--- a/taqueria-plugin-smartpy/README.md
+++ b/taqueria-plugin-smartpy/README.md
@@ -18,7 +18,7 @@ taq install @taqueria/plugin-smartpy
 ```
 
 > ### :page_with_curl: Note
-> You can override the SmartPy version used by the plugin by creating the environment variable `TAQ_SMARTPY_VERSION` and setting it to your desired version. E.g. `v0.16.0`
+> To override the SmartPy version used by the plugin, create an environmental variable `TAQ_SMARTPY_VERSION` and set it appropriately, e.g. `v0.16.0`
 
 ## The `taq compile` Task
 

--- a/taqueria-plugin-smartpy/_readme.eta
+++ b/taqueria-plugin-smartpy/_readme.eta
@@ -20,7 +20,7 @@ taq install @taqueria/plugin-smartpy
 ```
 
 <%~ it.noteOpenAdmonition %>
-You can override the SmartPy version used by the plugin by creating the environment variable `TAQ_SMARTPY_VERSION` and setting it to your desired version. E.g. `v0.16.0`
+To override the SmartPy version used by the plugin, create an environmental variable `TAQ_SMARTPY_VERSION` and set it appropriately, e.g. `v0.16.0`
 <%= it.closeAdmonition %>
 
 ## The `taq compile` Task

--- a/taqueria-plugin-smartpy/_readme.eta
+++ b/taqueria-plugin-smartpy/_readme.eta
@@ -19,6 +19,10 @@ To install the SmartPy plugin on a Taqueria project, navigate to the project fol
 taq install @taqueria/plugin-smartpy
 ```
 
+<%~ it.noteOpenAdmonition %>
+You can override the SmartPy version used by the plugin by creating the environment variable `TAQ_SMARTPY_VERSION` and setting it to your desired version. E.g. `v0.16.0`
+<%= it.closeAdmonition %>
+
 ## The `taq compile` Task
 
 Basic usage is:

--- a/taqueria-plugin-smartpy/common.ts
+++ b/taqueria-plugin-smartpy/common.ts
@@ -1,6 +1,5 @@
 import { execCmd, getArtifactsDir, getContractsDir, sendErr, sendWarn } from '@taqueria/node-sdk';
 import { ProxyTaskArgs } from '@taqueria/node-sdk/types';
-import { RequestArgs } from '@taqueria/node-sdk/types';
 import { access } from 'fs/promises';
 import { join } from 'path';
 
@@ -17,15 +16,46 @@ export type IntersectionOpts = CompileOpts & TestOpts;
 
 type UnionOpts = CompileOpts | TestOpts;
 
+// Should point to the latest stable version, so it needs to be updated as part of our release process.
+const SMARTPY_DEFAULT_VERSION = 'v0.16.0';
+
+const SMARTPY_VERSION_ENV_VAR = 'TAQ_SMARTPY_VERSION';
+
 const SMARTPY_ARTIFACTS_DIR = '.smartpy';
 
-// Should point to the latest version, so it needs to be updated as part of our release process.
-// Currently this points to v0.15.0
-const SMARTPY_INSTALLER =
-	'https://smartpy.io/releases/20221026-28e8c18e46035c353804eb5fd725573c5d434e8a/cli/install.sh';
+const smartpyVersionToInstallerMap: { [k: string]: string } = {
+	'v0.16.0': 'https://smartpy.io/releases/20221215-8f134ebb649f5a7b37c44fca8f336f970f523565/cli/install.sh',
+	'v0.15.0': 'https://smartpy.io/releases/20221026-28e8c18e46035c353804eb5fd725573c5d434e8a/cli/install.sh',
+	'v0.14.0': 'https://smartpy.io/releases/20220926-1c748c4572188f65a525792468e37da2182f18a2/cli/install.sh',
+};
 
-const SMARTPY_INSTALL_CMD =
-	`curl -s ${SMARTPY_INSTALLER} > ~/SmartPyCliInstaller.sh; bash ~/SmartPyCliInstaller.sh --yes; rm ~/SmartPyCliInstaller.sh`;
+const getSmartpyVersion = (): string => {
+	const userDefinedSmartpyVersion = process.env[SMARTPY_VERSION_ENV_VAR];
+	if (userDefinedSmartpyVersion) {
+		if (smartpyVersionToInstallerMap[userDefinedSmartpyVersion]) {
+			return userDefinedSmartpyVersion;
+		} else {
+			sendWarn(
+				`Version ${userDefinedSmartpyVersion} is not supported by Taqueria yet. Will default to ${SMARTPY_DEFAULT_VERSION}`,
+			);
+			return SMARTPY_DEFAULT_VERSION;
+		}
+	} else {
+		return SMARTPY_DEFAULT_VERSION;
+	}
+};
+
+const getPathToSmartPyCliDir = (): string => `${process.env.HOME}/smartpy-cli-${getSmartpyVersion()}`;
+
+const getSmartPyInstallerCmd = (): string => {
+	const installer = '~/SmartPyCliInstaller.sh';
+	const download = `curl -s ${smartpyVersionToInstallerMap[getSmartpyVersion()]} > ${installer};`;
+	const install = `bash ${installer} --yes --prefix ${getPathToSmartPyCliDir()};`;
+	const clean = `rm ${installer};`;
+	return download + install + clean;
+};
+
+export const getSmartPyCli = (): string => `${getPathToSmartPyCliDir()}/SmartPy.sh`;
 
 export const addPyExtensionIfMissing = (sourceFile: string): string =>
 	/\.py$/.test(sourceFile) ? sourceFile : `${sourceFile}.py`;
@@ -40,8 +70,6 @@ const removeExt = (path: string): string => {
 	return path.replace(extRegex, '');
 };
 
-export const getSmartPyCli = (): string => `${process.env.HOME}/smartpy-cli/SmartPy.sh`;
-
 export const getInputFilename = (parsedArgs: UnionOpts, sourceFile: string): string =>
 	join(getContractsDir(parsedArgs), sourceFile);
 
@@ -52,7 +80,7 @@ export const installSmartPyCliIfNotExist = () =>
 	access(getSmartPyCli())
 		.catch(() => {
 			sendWarn('SmartPy CLI not found. Installing it now...');
-			return execCmd(SMARTPY_INSTALL_CMD)
+			return execCmd(getSmartPyInstallerCmd())
 				.then(({ stderr }) => {
 					if (stderr.length > 0) sendWarn(stderr);
 				});

--- a/taqueria-plugin-smartpy/common.ts
+++ b/taqueria-plugin-smartpy/common.ts
@@ -36,7 +36,9 @@ const getSmartpyVersion = (): string => {
 			return userDefinedSmartpyVersion;
 		} else {
 			sendWarn(
-				`Version ${userDefinedSmartpyVersion} is not supported by Taqueria yet. Will default to ${SMARTPY_DEFAULT_VERSION}`,
+				`Version ${userDefinedSmartpyVersion} is not supported by Taqueria yet. The supported versions are [${
+					Object.keys(smartpyVersionToInstallerMap)
+				}]. Will default to ${SMARTPY_DEFAULT_VERSION}`,
 			);
 			return SMARTPY_DEFAULT_VERSION;
 		}

--- a/taqueria-plugin-smartpy/common.ts
+++ b/taqueria-plugin-smartpy/common.ts
@@ -47,6 +47,8 @@ const getSmartpyVersion = (): string => {
 
 const getPathToSmartPyCliDir = (): string => `${process.env.HOME}/smartpy-cli-${getSmartpyVersion()}`;
 
+export const getSmartPyCli = (): string => `${getPathToSmartPyCliDir()}/SmartPy.sh`;
+
 const getSmartPyInstallerCmd = (): string => {
 	const installer = '~/SmartPyCliInstaller.sh';
 	const download = `curl -s ${smartpyVersionToInstallerMap[getSmartpyVersion()]} > ${installer};`;
@@ -54,8 +56,6 @@ const getSmartPyInstallerCmd = (): string => {
 	const clean = `rm ${installer};`;
 	return download + install + clean;
 };
-
-export const getSmartPyCli = (): string => `${getPathToSmartPyCliDir()}/SmartPy.sh`;
 
 export const addPyExtensionIfMissing = (sourceFile: string): string =>
 	/\.py$/.test(sourceFile) ? sourceFile : `${sourceFile}.py`;

--- a/taqueria-plugin-smartpy/test.ts
+++ b/taqueria-plugin-smartpy/test.ts
@@ -32,10 +32,9 @@ const testContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =
 		})
 		.catch(err => {
 			emitExternalError(err, sourceFile);
-			const outputDir = getCompilationTargetsDirname(parsedArgs, sourceFile);
 			return {
 				contract: sourceFile,
-				testResults: `Some tests failed :(\nInspect the log files inside the test subfolders of\n"${outputDir}"`,
+				testResults: 'Some tests failed :(',
 			};
 		});
 


### PR DESCRIPTION
# 🌮 Taqueria PR

Fixes #1597

## 🪁 Description

Added ability to override SmartPy CLI by providing an environment variable called `TAQ_SMARTPY_VERSION`, similar to how it's done in other plugins.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [x] 🤿 Corresponding changes have been made to all documentation
- [x] 🚢 The release checklist has been completed

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾
- [x] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
