### PR TITLE
🛠️ Fix ➾ Use default location for Deno dependency caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,8 +100,6 @@ jobs:
       - name: Build the binary for ${{ matrix.os }}
         id: build-bin
         shell: bash
-        env:
-          DENO_DIR: "./deno"
         run: |
           BUILD=`git rev-parse --short "$GITHUB_SHA"`
           TAQ_VERSION="${TAQ_VERSION/\//-}"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -19,7 +19,7 @@ if [ "$0" == "./bin/build.sh" -a -f index.ts ]; then
         else
             TARGET_ARG="--target $DENO_TARGET"
         fi
-        DENO_DIR=./deno deno compile -o taq --allow-run --allow-write --allow-read --allow-env --allow-net --import-map ./import_map.json --no-prompt index.ts --setBuild "$BUILD" --setVersion "$TAQ_VERSION" --lock ./deno-lock.json $TARGET_ARG
+        deno compile -o taq --allow-run --allow-write --allow-read --allow-env --allow-net --import-map ./import_map.json --no-prompt index.ts --setBuild "$BUILD" --setVersion "$TAQ_VERSION" --lock ./deno-lock.json $TARGET_ARG
     fi
 else
     echo "Usage: ./bin/build.sh"

--- a/bin/debug.sh
+++ b/bin/debug.sh
@@ -4,4 +4,4 @@ source ./bin/set-vars.sh
 BIN_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 PROJ_DIR="${BIN_DIR}/.."
 
-DENO_DIR=./deno deno run --inspect-brk --allow-run --allow-write --allow-read --allow-env --allow-net --import-map "${PROJ_DIR}/import_map.json" "${PROJ_DIR}/index.ts" --setBuild "$BUILD" --setVersion "$TAQ_VERSION"  --lock ./deno-lock.json $@
+deno run --inspect-brk --allow-run --allow-write --allow-read --allow-env --allow-net --import-map "${PROJ_DIR}/import_map.json" "${PROJ_DIR}/index.ts" --setBuild "$BUILD" --setVersion "$TAQ_VERSION"  --lock ./deno-lock.json $@

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -5,7 +5,7 @@ BIN_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd
 PROJ_DIR="${BIN_DIR}/.."
 
 if [ "$0" == "./bin/run.sh" -a -f index.ts ]; then
-    DENO_DIR=./deno deno run --allow-run --allow-write --allow-read --allow-env --allow-net --import-map "${PROJ_DIR}/import_map.json" index.ts --setBuild "$BUILD" --setVersion "$TAQ_VERSION"  --lock ./deno-lock.json $@
+    deno run --allow-run --allow-write --allow-read --allow-env --allow-net --import-map "${PROJ_DIR}/import_map.json" index.ts --setBuild "$BUILD" --setVersion "$TAQ_VERSION"  --lock ./deno-lock.json $@
 else
     echo "Usage: ./bin/build.sh"
     echo "(please run from within project root)"


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Relates to #1646

Taqueria dev team reported errors with dependency imports when building Taqueria binaries locally. 

```
error: Import 'https://deno.land/x/ramda@v0.27.2/source/minBy.js' failed: 500 Internal Server Error
    at https://deno.land/x/ramda@v0.27.2/source/index.js:137:34
```

I've noticed that our build scripts set the `DENO_DIR` for dependencies caching inside the Taqueria project. These caches get deleted when running `git clean -fdx` 

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_
