### PR TITLE
✨ Feature ➾ added ability to deploy to mainnet and interact with contracts deployed there

### DIFF
--- a/taqueria-config.ts
+++ b/taqueria-config.ts
@@ -30,6 +30,10 @@ export const defaultConfig: Config.t = Config.create({
 			networks: ['ghostnet'],
 			sandboxes: [],
 		},
+		production: {
+			networks: ['mainnet'],
+			sandboxes: [],
+		},
 	},
 	sandbox: {
 		local: {
@@ -49,6 +53,11 @@ export const defaultConfig: Config.t = Config.create({
 		ghostnet: {
 			label: 'ghostnet',
 			rpcUrl: 'https://ghostnet.ecadinfra.com',
+			protocol: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
+		},
+		mainnet: {
+			label: 'mainnet',
+			rpcUrl: 'https://mainnet.api.tez.ie',
 			protocol: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
 		},
 	},

--- a/taqueria-plugin-taquito/originate.ts
+++ b/taqueria-plugin-taquito/originate.ts
@@ -136,6 +136,7 @@ const prepContractInfoForDisplay = async (
 };
 
 const originate = async (parsedArgs: Opts): Promise<void> => {
+	debugger;
 	const protocolArgs = RequestArgs.create(parsedArgs);
 	const env = getCurrentEnvironmentConfig(protocolArgs);
 	if (!env) return sendAsyncErr(`There is no environment called ${parsedArgs.env} in your config.json`);

--- a/taqueria-plugin-taquito/originate.ts
+++ b/taqueria-plugin-taquito/originate.ts
@@ -136,7 +136,6 @@ const prepContractInfoForDisplay = async (
 };
 
 const originate = async (parsedArgs: Opts): Promise<void> => {
-	debugger;
 	const protocolArgs = RequestArgs.create(parsedArgs);
 	const env = getCurrentEnvironmentConfig(protocolArgs);
 	if (!env) return sendAsyncErr(`There is no environment called ${parsedArgs.env} in your config.json`);

--- a/taqueria-protocol/types.ts
+++ b/taqueria-protocol/types.ts
@@ -385,6 +385,7 @@ export type NetworkAccountConfig = {
 	publicKey: NonEmptyString;
 	publicKeyHash: PublicKeyHash;
 	privateKey: NonEmptyString; /** TODO: Should this be secretKey: @see {SandboxAccountConfig} */
+	mnemonic?: NonEmptyString;
 };
 
 export type SandboxAccountConfig = {

--- a/taqueria-protocol/types.ts
+++ b/taqueria-protocol/types.ts
@@ -382,9 +382,9 @@ export type NetworkConfig = {
 };
 
 export type NetworkAccountConfig = {
-	publicKey: NonEmptyString;
-	publicKeyHash: PublicKeyHash;
-	privateKey: NonEmptyString; /** TODO: Should this be secretKey: @see {SandboxAccountConfig} */
+	publicKey?: NonEmptyString;
+	publicKeyHash?: PublicKeyHash;
+	privateKey?: NonEmptyString; /** TODO: Should this be secretKey: @see {SandboxAccountConfig} */
 	mnemonic?: NonEmptyString;
 };
 

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -583,8 +583,8 @@ export const getAccountPrivateKey = async (
 ): Promise<string> => {
 	if (!network.accounts) network.accounts = {};
 
-	if (!network.accounts[account]) {
-		const mnemonic = Bip39.generateMnemonic();
+	if (!network.accounts[account] || !network.accounts[account].privateKey) {
+		const mnemonic = network?.accounts?.[account]?.mnemonic ?? Bip39.generateMnemonic();
 		const signer = InMemorySigner.fromMnemonic({ mnemonic });
 		const tezos = new TezosToolkit(network.rpcUrl as string);
 		tezos.setSignerProvider(signer);
@@ -615,7 +615,9 @@ export const getAccountPrivateKey = async (
 		}
 	}
 
-	return network.accounts[account].privateKey;
+	const privateKey = network.accounts[account].privateKey;
+	if (!privateKey) return sendAsyncErr('The private key must exist after creating it');
+	return privateKey;
 };
 
 export const getDockerImage = (defaultImageName: string, envVarName: string): string =>

--- a/tests/e2e/data/taquito-funding-instructions.txt
+++ b/tests/e2e/data/taquito-funding-instructions.txt
@@ -1,4 +1,4 @@
-A keypair with public key hash tz3__address__ was generated for you.
+A keypair with public key hash tz__address__ was generated for you.
 To fund this account:
 1. Go to https://teztnets.xyz and click "Faucet" of the target testnet
 2. Copy and paste the above key into the wallet address field

--- a/tests/e2e/taqueria-plugin-taquito.spec.ts
+++ b/tests/e2e/taqueria-plugin-taquito.spec.ts
@@ -161,7 +161,7 @@ describe('E2E Testing for taqueria taquito plugin', () => {
 
 		const configPKH = configContents.network.fundnet.accounts.taqOperatorAccount.publicKeyHash;
 
-		expect(result.stderr.replace(/tz3\S+/, 'tz3__address__')).toEqual(
+		expect(result.stderr.replace(/tz\S+/, 'tz__address__')).toEqual(
 			await fsPromises.readFile('e2e/data/taquito-funding-instructions.txt', 'utf-8'),
 		);
 	});

--- a/website/docs/config/networks.mdx
+++ b/website/docs/config/networks.mdx
@@ -73,7 +73,7 @@ taq originate <contractName> --env testing
 Configuring a mainnet is quite similar to configuring a teztnet with one difference. Users must also create an account, with the mnemonic specified, within the network in order to interact with mainnet. See the example below:
 
 :::danger
-Improvements are on the way. However, we currently only support signing in memory and we require a mnemonic to be written in the config file, so do not commit this file or delete the mnemonic before doing so). This is not the safest way to interact with mainnet so proceed at your own risk
+Improvements are on the way. However, we currently only support signing in memory and we require a mnemonic to be written in the config file, so do not commit this file or delete the mnemonic before doing so). This is not the safest way to interact with mainnet so proceed with caution
 :::
 
 ```
@@ -81,7 +81,7 @@ Improvements are on the way. However, we currently only support signing in memor
     "label": "mainnet",
     "rpcUrl": "https://mainnet.api.tez.ie",
     "accounts": {
-        "user1": {
+        "tempUser": {
             "mnemonic": <12-24 words mnemonic generated via a wallet>
         }
     }
@@ -89,7 +89,16 @@ Improvements are on the way. However, we currently only support signing in memor
 ```
 
 :::note
-By default, Taqueria will create an environment called `production` that point to this network upon executing `taq init`
+By default, Taqueria will create an environment called `production` that point to this network upon executing `taq init`. For old projects, add the following to the `environment` field of the config file:
 :::
 
-To interact with mainnet using `user1`, users must include the `--env` and the `--sender` flags. E.g. `taq deploy counter --env production --sender user1`
+```
+"production": {
+    "networks": [
+        "mainnet"
+    ],
+    "sandboxes": []
+}
+```
+
+To interact with mainnet using `tempUser`, users must include the `--env` and the `--sender` flags. E.g. `taq deploy counter --env production --sender tempUser`

--- a/website/docs/config/networks.mdx
+++ b/website/docs/config/networks.mdx
@@ -1,9 +1,9 @@
 ---
-title: Testnet Configuration
+title: Testnet and Mainnet Configuration
 ---
 
 :::note
-This document details the configuration and use of Tezos testnets. If you are looking for information on running or originating to a sandbox, please see the Flextesa documentation [here](docs/plugins/plugin-flextesa)
+This document details the configuration and use of Tezos testnets and mainnet. If you are looking for information on running or originating to a sandbox, please see the Flextesa documentation [here](docs/plugins/plugin-flextesa)
 :::
 
 ## Introduction
@@ -59,10 +59,6 @@ Then create a new environment (you may follow the format of the environment call
 
 Taqueria will support all protocols available on the [teztnets.xyz](https://teztnets.xyz/) site. If you notice an issue with a recent protocol update, please report it as a bug [here](https://github.com/ecadlabs/taqueria/issues/new?assignees=&labels=bug%2Ctriage&template=bug_report.yml&title=%5BBug%5D%3A+)
 
-:::note
-Currently Taqueria only supports testnets. Support for mainnet will be added in a future release
-:::
-
 ## Targeting a Network
 
 Taqueria uses [Environments](/docs/config/environments) to target a specific network or sandbox. An environment is a named collection of network configurations which can be passed to the CLI using the `--env` flag
@@ -71,3 +67,29 @@ To target the `ghostnet` network we configured above using the `testing` environ
 ```shell
 taq originate <contractName> --env testing
 ```
+
+## Deploying and Transferring with Mainnet
+
+Configuring a mainnet is quite similar to configuring a teztnet with one difference. Users must also create an account, with the mnemonic specified, within the network in order to interact with mainnet. See the example below:
+
+:::danger
+Improvements are on the way. However, we currently only support signing in memory and we require a mnemonic to be written in the config file, so do not commit this file or delete the mnemonic before doing so). This is not the safest way to interact with mainnet so proceed at your own risk
+:::
+
+```
+"mainnet": {
+    "label": "mainnet",
+    "rpcUrl": "https://mainnet.api.tez.ie",
+    "accounts": {
+        "user1": {
+            "mnemonic": <12-24 words mnemonic generated via a wallet>
+        }
+    }
+}
+```
+
+:::note
+By default, Taqueria will create an environment called `production` that point to this network upon executing `taq init`
+:::
+
+To interact with mainnet using `user1`, users must include the `--env` and the `--sender` flags. E.g. `taq deploy counter --env production --sender user1`

--- a/website/docs/config/networks.mdx
+++ b/website/docs/config/networks.mdx
@@ -73,7 +73,7 @@ taq originate <contractName> --env testing
 Configuring a mainnet is quite similar to configuring a teztnet with one difference. Users must also create an account, with the mnemonic specified, within the network in order to interact with mainnet. See the example below:
 
 :::danger
-Improvements are on the way. However, we currently only support signing in memory and we require a mnemonic to be written in the config file, so do not commit this file or delete the mnemonic before doing so). This is not the safest way to interact with mainnet so proceed with caution
+Improvements are on the way. However, we currently only support signing in memory and we require a mnemonic to be written in the config file, so do not commit this file or delete the mnemonic before doing so. This is not the safest way to interact with mainnet so proceed with caution
 :::
 
 ```


### PR DESCRIPTION
# 🌮 Taqueria PR

Fixes #1598

## 🪁 Description

Added the ability to deploy and interact with mainnet.
- Allow mnemonic to be specified in the config.
- Create a new environment called production that points to a newly created network called mainnet.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [x] 🤿 Corresponding changes have been made to all documentation
- [x] 🚢 The release checklist has been completed

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [ ] 🛠️ Fix ➾
- [x] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
