### PR TITLE
🛠️ Fix ➾ Don't generate ephemeral state twice when installing/uninstalling plugins

### DIFF
--- a/plugins.ts
+++ b/plugins.ts
@@ -230,6 +230,8 @@ export const inject = (deps: PluginDeps) => {
 					'scaffoldProjectDir',
 				];
 
+				if (key === 'help') val = false;
+
 				// If env is missing, then set it to the default environment of the config
 				if (key === 'env' && !val) val = config.environment?.default ?? 'development';
 

--- a/tests/e2e/taqueria-plugin-ligo.spec.ts
+++ b/tests/e2e/taqueria-plugin-ligo.spec.ts
@@ -77,7 +77,7 @@ describe('Ligo Plugin E2E Testing for Taqueria CLI', () => {
 		if (stderr.length > 0) console.error(stderr); // useful for debugging
 		expect(stdout).toContain('Plugin installed successfully');
 
-		const { stdout: stdout2 } = await execute('taq', 'compile --help --projectDir=./test-project', './test-project');
+		const { stdout: stdout2 } = await execute('taq', 'compile --help', './test-project');
 		expect(stdout2).toEqual(
 			expect.arrayContaining(['Compile a smart contract written in a LIGO syntax to Michelson code, along with']),
 		);

--- a/tests/e2e/taqueria-plugin-ligo.spec.ts
+++ b/tests/e2e/taqueria-plugin-ligo.spec.ts
@@ -63,7 +63,7 @@ describe('Ligo Plugin E2E Testing for Taqueria CLI', () => {
 		expect(stdout).toContain('Plugin installed successfully');
 
 		const { stdout: stdout2 } = await execute('taq', '--help', './test-project');
-		expect(stdout2).toEqual(expect.arrayContaining(['taq [command]']));
+		expect(stdout2).toEqual(expect.arrayContaining(['taq <command>']));
 
 		await cleanup();
 	});

--- a/tests/e2e/taqueria-plugin-ligo.spec.ts
+++ b/tests/e2e/taqueria-plugin-ligo.spec.ts
@@ -62,7 +62,7 @@ describe('Ligo Plugin E2E Testing for Taqueria CLI', () => {
 		if (stderr.length > 0) console.error(stderr); // useful for debugging
 		expect(stdout).toContain('Plugin installed successfully');
 
-		const { stdout: stdout2 } = await execute('taq', '--help --projectDir=./test-project', './test-project');
+		const { stdout: stdout2 } = await execute('taq', '--help', './test-project');
 		expect(stdout2).toEqual(expect.arrayContaining(['taq [command]']));
 
 		await cleanup();

--- a/tests/e2e/taqueria-plugin-ligo.spec.ts
+++ b/tests/e2e/taqueria-plugin-ligo.spec.ts
@@ -69,7 +69,7 @@ describe('Ligo Plugin E2E Testing for Taqueria CLI', () => {
 	});
 
 	// blocked by https://github.com/ecadlabs/taqueria/issues/1635
-	test.skip('compile will show contextual help', async () => {
+	test('compile will show contextual help', async () => {
 		const { execute, cleanup, spawn } = await prepareEnvironment();
 		const { waitForText } = await spawn('taq', 'init test-project --debug');
 		await waitForText("Project taq'ified!");


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

I forgot that in the internal task refactor work we re-generate the ephemeral state after the install task is run. However, this was using an outdated version of LoadedConfig in memory (the plugins property was out of date).

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Ensures that you can do the following and get contextual help:
```
taq init test-project && cd test-project && taq install [path to local flextesa plugin] && taq start sandbox --help
```

Expected output:
```
taq start sandbox [sandboxName]

Starts a flextesa sandbox

Positionals:
  sandboxName  The name of the sandbox to start

Options:
  -p, --projectDir  Path to your project directory               [default: "./"]
  -e, --env         Specify an environment configuration
      --version     Show version number                                [boolean]
      --build       Display build information about the current version[boolean]
  -y, --yes         Select "yes" to any prompt        [boolean] [default: false]
      --help        Show help                                          [boolean]
```