### PR TITLE
🛠️ Fix ➾ Use the hash of the latest protocol supported by the image as opposed to using Alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,10 +6593,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/@taqueria/flextesa-manager": {
-			"resolved": "taqueria-flextesa-manager",
-			"link": true
-		},
 		"node_modules/@taqueria/node-sdk": {
 			"resolved": "taqueria-sdk",
 			"link": true
@@ -7194,15 +7190,6 @@
 			"resolved": "https://registry.npmjs.org/@types/promise-memoize/-/promise-memoize-1.2.1.tgz",
 			"integrity": "sha512-QZBczXmJZOLlefxGvMJn8Y5sn7dMNTKcjKaYJ3kNbzUDz5c9rgfk24yPnY3I5xuLd2u3SjD33KV9nA69nDiX0A==",
 			"dev": true
-		},
-		"node_modules/@types/promise-retry": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
-			"integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
-			"dev": true,
-			"dependencies": {
-				"@types/retry": "*"
-			}
 		},
 		"node_modules/@types/prompts": {
 			"version": "2.4.2",
@@ -22481,6 +22468,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
 			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+			"dev": true,
 			"dependencies": {
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
@@ -22492,12 +22480,14 @@
 		"node_modules/promise-retry/node_modules/err-code": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+			"dev": true
 		},
 		"node_modules/promise-retry/node_modules/retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -29020,6 +29010,7 @@
 		},
 		"taqueria-flextesa-manager": {
 			"version": "0.25.16-rc",
+			"extraneous": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@taqueria/node-sdk": "^0.25.16-rc",
@@ -29036,6 +29027,7 @@
 			}
 		},
 		"taqueria-plugin-archetype": {
+			"name": "@taqueria/plugin-archetype",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29054,6 +29046,7 @@
 			"integrity": "sha512-LD+wFR/RNckk1DrKV0LTH4KIT9wRqnnOjtEf77ovhKcVi8gf83Uf6U7OdywEua6KD9SbHadUdfolayfIUiPxzw=="
 		},
 		"taqueria-plugin-contract-types": {
+			"name": "@taqueria/plugin-contract-types",
 			"version": "0.25.16-rc",
 			"license": "ISC",
 			"dependencies": {
@@ -29082,6 +29075,7 @@
 			"dev": true
 		},
 		"taqueria-plugin-core": {
+			"name": "@taqueria/plugin-core",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29096,6 +29090,7 @@
 			}
 		},
 		"taqueria-plugin-flextesa": {
+			"name": "@taqueria/plugin-flextesa",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29103,7 +29098,8 @@
 				"@taqueria/protocol": "^0.25.16-rc",
 				"async-retry": "^1.3.3",
 				"fast-glob": "^3.2.11",
-				"portfinder": "^1.0.28"
+				"portfinder": "^1.0.28",
+				"rambda": "^7.4.0"
 			},
 			"devDependencies": {
 				"@types/async-retry": "^1.4.4",
@@ -29112,6 +29108,7 @@
 			}
 		},
 		"taqueria-plugin-ipfs-pinata": {
+			"name": "@taqueria/plugin-ipfs-pinata",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29141,6 +29138,7 @@
 			}
 		},
 		"taqueria-plugin-jest": {
+			"name": "@taqueria/plugin-jest",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29177,6 +29175,7 @@
 			}
 		},
 		"taqueria-plugin-ligo": {
+			"name": "@taqueria/plugin-ligo",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29189,6 +29188,7 @@
 			}
 		},
 		"taqueria-plugin-metadata": {
+			"name": "@taqueria/plugin-metadata",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29216,6 +29216,7 @@
 			}
 		},
 		"taqueria-plugin-mock": {
+			"name": "@taqueria/plugin-mock",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29223,6 +29224,7 @@
 			}
 		},
 		"taqueria-plugin-smartpy": {
+			"name": "@taqueria/plugin-smartpy",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29238,6 +29240,7 @@
 			}
 		},
 		"taqueria-plugin-taquito": {
+			"name": "@taqueria/plugin-taquito",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29256,6 +29259,7 @@
 			}
 		},
 		"taqueria-plugin-tezos-client": {
+			"name": "@taqueria/plugin-tezos-client",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29271,6 +29275,7 @@
 			}
 		},
 		"taqueria-protocol": {
+			"name": "@taqueria/protocol",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29289,6 +29294,7 @@
 			}
 		},
 		"taqueria-sdk": {
+			"name": "@taqueria/node-sdk",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29322,6 +29328,7 @@
 			"dev": true
 		},
 		"taqueria-state": {
+			"name": "@taqueria/state",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29341,6 +29348,7 @@
 			"dev": true
 		},
 		"taqueria-toolkit": {
+			"name": "@taqueria/toolkit",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"devDependencies": {
@@ -29356,6 +29364,7 @@
 			"dev": true
 		},
 		"taqueria-vscode-extension": {
+			"name": "taqueria-vscode",
 			"version": "0.25.16",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -29415,7 +29424,8 @@
 			}
 		},
 		"tests": {
-			"version": "0.25.16-rc",
+			"name": "@taqueria/tests",
+			"version": "0.27.2-alpha",
 			"license": "MIT",
 			"devDependencies": {
 				"@taquito/signer": "^15.0.0",
@@ -35431,20 +35441,6 @@
 				"defer-to-connect": "^1.0.1"
 			}
 		},
-		"@taqueria/flextesa-manager": {
-			"version": "file:taqueria-flextesa-manager",
-			"requires": {
-				"@taqueria/node-sdk": "^0.25.16-rc",
-				"@types/promise-retry": "^1.1.3",
-				"esbuild": "^0.14.39",
-				"execa": "^6.1.0",
-				"promise-retry": "^2.0.1",
-				"tsup": "^6.4.0",
-				"typescript": "^4.7.2",
-				"yargs": "^17.5.1",
-				"zod": "^3.17.3"
-			}
-		},
 		"@taqueria/node-sdk": {
 			"version": "file:taqueria-sdk",
 			"requires": {
@@ -35538,6 +35534,7 @@
 				"async-retry": "^1.3.3",
 				"fast-glob": "^3.2.11",
 				"portfinder": "^1.0.28",
+				"rambda": "*",
 				"tsup": "^6.1.3",
 				"typescript": "^4.7.2"
 			}
@@ -37026,15 +37023,6 @@
 			"resolved": "https://registry.npmjs.org/@types/promise-memoize/-/promise-memoize-1.2.1.tgz",
 			"integrity": "sha512-QZBczXmJZOLlefxGvMJn8Y5sn7dMNTKcjKaYJ3kNbzUDz5c9rgfk24yPnY3I5xuLd2u3SjD33KV9nA69nDiX0A==",
 			"dev": true
-		},
-		"@types/promise-retry": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
-			"integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
-			"dev": true,
-			"requires": {
-				"@types/retry": "*"
-			}
 		},
 		"@types/prompts": {
 			"version": "2.4.2",
@@ -48408,6 +48396,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
 			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+			"dev": true,
 			"requires": {
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
@@ -48416,12 +48405,14 @@
 				"err-code": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-					"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+					"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+					"dev": true
 				},
 				"retry": {
 					"version": "0.12.0",
 					"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-					"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+					"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+					"dev": true
 				}
 			}
 		},

--- a/taqueria-plugin-flextesa/package.json
+++ b/taqueria-plugin-flextesa/package.json
@@ -38,7 +38,8 @@
 		"@taqueria/protocol": "^0.25.16-rc",
 		"async-retry": "^1.3.3",
 		"fast-glob": "^3.2.11",
-		"portfinder": "^1.0.28"
+		"portfinder": "^1.0.28",
+		"rambda": "^7.4.0"
 	},
 	"devDependencies": {
 		"@types/async-retry": "^1.4.4",


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

In our config.json file, we can omit the protocol to use in our flextesa sandbox. In that case, the flextesa image would just use 'Alpha' as the protocol hash when starting the node. This PR adjusts that so that the latest protocol hash supported by the image is used instead.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] 🔱 The test plan has been implemented and verified by an SDET
- [x] 🦀 Automated tests have been written and added to this PR
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [x] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

- getProtocolsSupported() is now memoized so that it can be called multiple times without having to call a docker child process for each invocation
- getProtocolKind() will now return the hash of the latest protocol as opposed to Alpha

## 🎢 Test Plan

In main, start a sandbox and then run `docker logs` against the container running tztk-sync and you'll see errors.

Use this branch, start a sandbox, and then run `docker logs` against the container running tztk-sync and you'll see _no_ errors.