### PR TITLE
🛠️ Fix ➾ Added better error handling to the SDK

### DIFF
--- a/taqueria-plugin-mock/index.js
+++ b/taqueria-plugin-mock/index.js
@@ -10,6 +10,18 @@ const tableResponse = JSON.stringify({
 	data: [{ ping: 'pong' }],
 });
 
+// If the CLI has requested an invalid-schema, then we modify
+// the schema to make it invalid
+const processArgs = (() => {
+	if (!process.argv.includes('--invalidSchema')) return process.argv;
+	const configIndex = process.argv.indexOf('--config') + 1;
+	const json = JSON.parse(process.argv[configIndex]);
+	json.accounts.secretKey = 'my secret key';
+	json.accounts.privateKey = 'my private key';
+	process.argv[configIndex] = JSON.stringify(json);
+	return process.argv;
+})();
+
 Plugin.create(i18n => ({
 	schema: '1.0',
 	version: '0.1',
@@ -191,4 +203,4 @@ echo 'Hi there, <%= greeting %>!' ><%= outputFile %>
 			}
 		}
 	},
-}), process.argv);
+}), processArgs);

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -700,13 +700,63 @@ const getPackageName = () => {
 	return generateName().dashed;
 };
 
+export const isTaqError = (err: unknown): err is TaqError => {
+	return (err as TaqError).kind !== undefined;
+};
+
+// Creates a writable stream that sanitizes the data being written to the stream
+// We then create a new console that uses this stream for stderr
+const sanitizedStderrWriter = () => {
+	const stream = require('stream');
+	const { Console } = require('console');
+	const writable = stream.Writable({
+		write(chunk: Buffer, _encoding: string, next: () => void) {
+			console.error(chunk.toString('utf8').replaceAll(/("[^"]+key\"):("[^"]+\")/gi, `$1:"[hidden]"`));
+			next();
+		},
+	});
+	return new Console(process.stdout, writable);
+};
+
+// Outputs the error using console.error (so that the error is formatted) but
+// uses a custom writable stream that sanitizes the data first
+const outputSanitizedErr = (err: unknown) => {
+	const console = sanitizedStderrWriter();
+	console.error(err);
+};
+
 export const Plugin = {
 	create: <Args extends Protocol.RequestArgs.t>(definer: pluginDefiner, unparsedArgs: string[]) => {
 		const packageName = getPackageName();
 		return parseArgs<Args>(unparsedArgs)
 			.then(getResponse(definer, packageName))
 			.catch((err: unknown) => {
-				if (err) console.error(err);
+				if (err) {
+					const debug = unparsedArgs.join(',').includes(['--debug', true].join(','));
+
+					// Handle Zod parsing errors
+					if (isTaqError(err) && err.kind === 'E_PARSE' && err.previous && err.previous instanceof ZodError) {
+						const msgs: string[] = err.previous.errors.reduce(
+							(retval, issue) => {
+								const path = issue.path.join(' → ');
+								const msg = `  ${path}: ${issue.message}`;
+								return [...retval, msg];
+							},
+							[`Taqueria tried to send data to ${packageName} that it couldn't parse or understand. This is most likely due to the version of the plugin being out-of-date and incompatible with the CLI or vice versa. More details:`],
+						);
+						console.error(msgs.join('\n') + '\n');
+					} // Handle simple string errors
+					else if (typeof err === 'string') console.error(err);
+					// Handle edge cases
+					else if (!debug) {
+						console.error(`${packageName} encountered an unexpected problem. Use --debug to learn more.`);
+					}
+
+					// Show the entire err if the debug flag is provided
+					if (debug) {
+						outputSanitizedErr(err);
+					}
+				}
 				process.exit(1);
 			});
 	},

--- a/tests/integration/plugin-mock.spec.ts
+++ b/tests/integration/plugin-mock.spec.ts
@@ -1,7 +1,10 @@
-import { execSync, spawnSync } from 'child_process';
+import { exec as exec1, execSync, spawnSync } from 'child_process';
 import { readFile, rm } from 'fs/promises';
 import { join } from 'path';
+import util from 'util';
 import { generateTestProject } from '../e2e/utils/utils';
+const exec = util.promisify(exec1);
+
 const testProjectPath = 'scrap/auto-test-integration';
 
 const tableOutput = `
@@ -112,6 +115,26 @@ describe('Integration tests using taqueria-mock-plugin', () => {
 
 		const output = await readFile(join(testProjectPath, 'artifacts', 'hello.json'), 'utf-8');
 		expect(output).toEqual('{"greeting":"Hello, QA Team!"}');
+	});
+
+	test('Verify that if an invalid schema is used, error messaging works as expected', async () => {
+		const withoutDebug = await exec('taq proxy --invalid-schema || true', {
+			cwd: testProjectPath,
+			encoding: 'utf-8',
+		});
+		expect(withoutDebug.stderr).toContain(
+			'@taqueria/plugin-mock encountered an unexpected problem. Use --debug to learn more.',
+		);
+
+		const withDebug = await exec('taq proxy --invalid-schema --debug || true', {
+			cwd: testProjectPath,
+			encoding: 'utf-8',
+		});
+		expect(withDebug.stderr).not.toEqual(
+			'@taqueria/plugin-mock encountered an unexpected problem. Use --debug to learn more.',
+		);
+		expect(withDebug.stderr).toContain(`"secretKey":"[hidden]"`);
+		expect(withDebug.stderr).toContain(`"privateKey":"[hidden]"`);
 	});
 
 	// Clean up process to remove taqified project folder


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

When the SDK encountered a zod error (or any error), it would just output the error to stderr using `console.error(err)`.

Instead, we should provide more granular error handling and too, ensure that our output is sanitized (so that it doesn't leak private information).

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] 🔱 The test plan has been implemented and verified by an SDET
- [x] 🦀 Automated tests have been written and added to this PR
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

- Added the start of more granular error handling in the SDK's Plugin.create() call
- Only output the message unless the `--debug` flag is provided.
- Sanitize output to swap any private or secret keys with _[hidden]_ as a value.
- Extended the mock plugin to provide a response for invalid schema data

## 🎢 Test Plan

I added an integration test using the mock plugin to assure that the error messaging is appropriate.