### PR TITLE
🛠️ Fix ➾ Added analytics event tracking to vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7386,9 +7386,9 @@
 			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.63.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.0.tgz",
-			"integrity": "sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==",
+			"version": "1.73.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.0.tgz",
+			"integrity": "sha512-FhkfF7V3fj7S3WqXu7AxFesBLO3uMkdCPJJPbwyZXezv2xJ6xBWHYM2CmkkbO8wT9Fr3KipwxGGOoQRrYq7mHg==",
 			"dev": true
 		},
 		"node_modules/@types/ws": {
@@ -30503,6 +30503,7 @@
 			}
 		},
 		"taqueria-analytics": {
+			"name": "@taqueria/analytics",
 			"version": "0.25.16-rc",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -30856,6 +30857,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@microsoft/signalr": "^6.0.8",
+				"@taqueria/analytics": "^0.25.16-rc",
 				"@taqueria/protocol": "^0.25.16-rc",
 				"cli-table3": "^0.6.2",
 				"comment-json": "^4.1.1",
@@ -30874,7 +30876,7 @@
 				"@types/node": "^17.0.17",
 				"@types/promise-memoize": "^1.2.1",
 				"@types/semver": "^7.3.10",
-				"@types/vscode": "1.63.0",
+				"@types/vscode": "1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.9.1",
 				"@typescript-eslint/parser": "^5.9.1",
 				"@vscode/test-electron": "^2.1.2",
@@ -38700,9 +38702,9 @@
 			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
 		},
 		"@types/vscode": {
-			"version": "1.63.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.0.tgz",
-			"integrity": "sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==",
+			"version": "1.73.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.0.tgz",
+			"integrity": "sha512-FhkfF7V3fj7S3WqXu7AxFesBLO3uMkdCPJJPbwyZXezv2xJ6xBWHYM2CmkkbO8wT9Fr3KipwxGGOoQRrYq7mHg==",
 			"dev": true
 		},
 		"@types/ws": {
@@ -53222,6 +53224,7 @@
 			"version": "file:taqueria-vscode-extension",
 			"requires": {
 				"@microsoft/signalr": "^6.0.8",
+				"@taqueria/analytics": "^0.25.16-rc",
 				"@taqueria/protocol": "^0.25.16-rc",
 				"@taquito/taquito": "^15.0.0",
 				"@types/fs-extra": "^9.0.13",
@@ -53230,7 +53233,7 @@
 				"@types/node": "^17.0.17",
 				"@types/promise-memoize": "^1.2.1",
 				"@types/semver": "^7.3.10",
-				"@types/vscode": "1.63.0",
+				"@types/vscode": "1.73.0",
 				"@typescript-eslint/eslint-plugin": "^5.9.1",
 				"@typescript-eslint/parser": "^5.9.1",
 				"@vscode/test-electron": "^2.1.2",

--- a/taqueria-analytics/index.ts
+++ b/taqueria-analytics/index.ts
@@ -16,7 +16,7 @@ const toRequestURI = () =>
 	`https://www.google-analytics.com/mp/collect?measurement_id=${MEASUREMENT_ID}&api_secret=${API_SECRET}`;
 
 export const inject = ({ taqVersion, taqBuild, fields, getMachineId, operatingSystem, fetch, ...deps }: Deps) => {
-	const events: StoredEvent[] = [];
+	let events: StoredEvent[] = [];
 
 	const toRequestBody = (client_id: string) =>
 		JSON.stringify({
@@ -39,11 +39,15 @@ export const inject = ({ taqVersion, taqBuild, fields, getMachineId, operatingSy
 			},
 		});
 
+	const empty = () => {
+		events = [];
+	};
+
 	const sendEvents = () =>
 		getMachineId()
 			.then(toRequestBody)
 			.then((body: string) => fetch(toRequestURI(), { method: 'POST', body }))
-			.then(noop)
+			.then(empty)
 			.catch(noop);
 
 	const isTrackingAllowed = () => deps.settings.consent === 'opt_in';

--- a/taqueria-analytics/types.ts
+++ b/taqueria-analytics/types.ts
@@ -27,5 +27,5 @@ export type Deps = {
 	taqBuild: string; // build of the taqueria CLI
 	fields?: EventParams; // other common fields to include in the event
 	getMachineId: () => Promise<string>; // function used to determine the machine id
-	fetch: (uri: string, opts: Record<string, unknown>) => Promise<{ json: () => Promise<Record<string, unknown>> }>;
+	fetch: (uri: string, opts: Record<string, unknown>) => Promise<unknown>;
 };

--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -766,7 +766,7 @@
 		"@types/node": "^17.0.17",
 		"@types/promise-memoize": "^1.2.1",
 		"@types/semver": "^7.3.10",
-		"@types/vscode": "1.63.0",
+		"@types/vscode": "1.73.0",
 		"@typescript-eslint/eslint-plugin": "^5.9.1",
 		"@typescript-eslint/parser": "^5.9.1",
 		"@vscode/test-electron": "^2.1.2",
@@ -780,6 +780,7 @@
 	},
 	"dependencies": {
 		"@microsoft/signalr": "^6.0.8",
+		"@taqueria/analytics": "^0.25.16-rc",
 		"@taqueria/protocol": "^0.25.16-rc",
 		"cli-table3": "^0.6.2",
 		"comment-json": "^4.1.1",

--- a/taqueria-vscode-extension/src/extension.ts
+++ b/taqueria-vscode-extension/src/extension.ts
@@ -11,4 +11,5 @@ export async function activate(context: vscode.ExtensionContext, input?: Injecte
 
 export function deactivate() {
 	helper.watchers.clearConfigWatchers();
+	helper.sendEvents();
 }

--- a/taqueria-vscode-extension/src/lib/pure.ts
+++ b/taqueria-vscode-extension/src/lib/pure.ts
@@ -180,6 +180,22 @@ export const checkTaqVersion = async (
 	return result.standardOutput;
 };
 
+export const checkTaqBuild = async (
+	inputPath: PathToTaq,
+	i18n: i18n,
+	showOutput: OutputFunction,
+	helper: VsCodeHelper,
+): Promise<string> => {
+	const result = await execCmd(`${inputPath} --build --fromVsCode`, showOutput);
+	if (result.executionError) {
+		helper.logAllNestedErrors(result.executionError);
+	}
+	if (result.standardError && result.standardError.length) {
+		showOutput(OutputLevels.error, result.standardError);
+	}
+	return result.standardOutput;
+};
+
 export const getNodeVersion = async (showOutput: OutputFunction) => {
 	const result = await execCmd(`node --version`, showOutput);
 	const version = result.standardOutput;

--- a/taqueria-vscode-extension/src/lib/settings.ts
+++ b/taqueria-vscode-extension/src/lib/settings.ts
@@ -1,0 +1,11 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+import * as Settings from '@taqueria/protocol/Settings';
+
+export { Settings };
+
+export const getSettings = () =>
+	readFile(join(process.env.HOME!, '.taq-settings', 'taq-settings.json'), 'utf8')
+		.then(JSON.parse)
+		.then(Settings.create);


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Added analytics tracking to vscode

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

- Included the `@taqueria/analytics` library in vscode
- Send the `taq_vscode_loaded` event when the vscode extension is loaded
- Bumped the type definitions for the vscode API to a later version (not the latest, so that we're at least still some-what backwards compatible with earlier versions of vscode)