### PR TITLE
Use official TzKt images

### DIFF
--- a/taqueria-plugin-flextesa/tzkt-manager.ts
+++ b/taqueria-plugin-flextesa/tzkt-manager.ts
@@ -5,8 +5,8 @@ import { ValidOpts } from './types';
 
 const getTzKtDockerImages = (opts: ValidOpts) => ({
 	postgres: `postgres:14.5-alpine`,
-	sync: `ghcr.io/ecadlabs/tzkt-sync:v1.11.0-taqueria`,
-	api: `ghcr.io/ecadlabs/tzkt-api:v1.11.0-taqueria`,
+	sync: `bakingbad/tzkt-sync:1.11.1`,
+	api: `bakingbad/tzkt-api:1.11.1`,
 });
 
 export const getTzKtContainerNames = async (sandboxName: string, parsedArgs: ValidOpts) => {

--- a/taqueria-plugin-flextesa/tzkt-manager.ts
+++ b/taqueria-plugin-flextesa/tzkt-manager.ts
@@ -25,7 +25,8 @@ const getTzKtContainerEnvironments = async (sandboxName: string, sandbox: Sandbo
 		`ConnectionStrings__DefaultConnection="host=${containerNames.postgres};port=5432;database=sandbox_data;username=tzkt;password=${sandboxName};"`;
 	return {
 		postgres: `--env POSTGRES_PASSWORD=${sandboxName} --env POSTGRES_USER=tzkt`,
-		sync: `--env ${connectionStringEnv} --env TezosNode__Endpoint="http://${sandboxContainerName}:20000/"`,
+		sync:
+			`--env ${connectionStringEnv} --env TezosNode__Endpoint="http://${sandboxContainerName}:20000/" --env Protocols__Fallback="PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW"`,
 		api:
 			`--env ${connectionStringEnv} --env Kestrel__Endpoints__Http__Url="http://*:5000" --env MaxAttemptsForMigrations=120`,
 	};


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Previously we had to maintain our own fork and docker image of TzKt because:
1. TzKt was using .net 5 which was not running on m1 mac
2. TzKt could not work with protocol Alpha
3. TzKt.Api did not wait long enough (in our setup) for TzKt.Sync to create the database schema.

The Baking Bad team had decided to skip .net 6 because of a Json serialization incompatibility, but when they migrated to .net 7, we could use their image. We opened a PR: baking-bad/tzkt#139 to fix our other problems and now we can use their image.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [x] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Switched to Official TzKt images from BakingBad

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾ Switched to Official TzKt images from Baking Bad
- [ ] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
