### PR TITLE
Fix Monitoring for Changes in TVsCE

### DIFF
--- a/taqueria-vscode-extension/src/lib/helpers.ts
+++ b/taqueria-vscode-extension/src/lib/helpers.ts
@@ -246,9 +246,6 @@ export class VsCodeHelper {
 		this.exposeShowOperationDetailsCommand();
 		this.exposeInvokeEntrypointCommand();
 
-		await this.registerDataProviders();
-		this.createTreeViews();
-
 		this.vscode.workspace.onDidChangeWorkspaceFolders(async e => {
 			for (const folder of e.added) {
 				try {
@@ -265,6 +262,10 @@ export class VsCodeHelper {
 				this.logAllNestedErrors(error);
 			}
 		});
+
+		await this.registerDataProviders();
+		this.createTreeViews();
+
 		await this.updateCommandStates();
 
 		// When there workspace changes, sent all tracked events
@@ -1500,7 +1501,7 @@ export class VsCodeHelper {
 			try {
 				const taqFolderWatcher = this.vscode.workspace.createFileSystemWatcher(join(projectDir, '.taq'));
 				this._taqFolderWatcher = taqFolderWatcher;
-				const configWatcher = this.vscode.workspace.createFileSystemWatcher(join(projectDir, '.taq/config.json'));
+				const configWatcher = this.vscode.workspace.createFileSystemWatcher(join(projectDir, '.taq/config*.json'));
 				this._configWatcher = configWatcher;
 				const stateWatcher = this.vscode.workspace.createFileSystemWatcher(join(projectDir, '.taq/state.json'));
 				this._stateWatcher = stateWatcher;


### PR DESCRIPTION
# 🌮 Taqueria PR

Closes #1772 
Closes #1781 

## 🪁 Description

TVsCE monitors for changes to the `.taq/config.json`. After configuration redesign, we now have files like `.taq/config.local.development.json`. Changes to these files should also be monitored. This was the root cause for bug #1772 

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Watch changes to all files matching `.taq/config*.json` such as `.taq/config.local.development.json`.

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾ TVsCE does not reload config when a file like `.taq/config.local.development.json` changes
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
