### PR TITLE
✨ Feature ➾ implement `taq compile-all` for the LIGO and SmartPy plugin

### DIFF
--- a/taqueria-plugin-ligo/README.md
+++ b/taqueria-plugin-ligo/README.md
@@ -55,6 +55,16 @@ Lastly, `taq compile hello.mligo` will compile `hello.mligo` and emit `hello.tz`
 
 The `--json` flag will make the task emit JSON-encoded Michelson instead of pure Michelson `.tz`
 
+## The `taq compile-all` Task
+
+Basic usage is:
+
+```shell
+taq compile-all
+```
+
+It works just like the `compile` task but it compiles all main contracts, a.k.a contracts with a `main` function.
+
 ## The `taq test` Task
 
 Basic usage is:

--- a/taqueria-plugin-ligo/_readme.eta
+++ b/taqueria-plugin-ligo/_readme.eta
@@ -60,6 +60,16 @@ Lastly, `taq compile hello.mligo` will compile `hello.mligo` and emit `hello.tz`
 
 The `--json` flag will make the task emit JSON-encoded Michelson instead of pure Michelson `.tz`
 
+## The `taq compile-all` Task
+
+Basic usage is:
+
+```shell
+taq compile-all
+```
+
+It works just like the `compile` task but it compiles all main contracts, a.k.a contracts with a `main` function.
+
 ## The `taq test` Task
 
 Basic usage is:

--- a/taqueria-plugin-ligo/common.ts
+++ b/taqueria-plugin-ligo/common.ts
@@ -11,14 +11,18 @@ export interface CompileOpts extends ProxyTaskArgs.t {
 	json: boolean;
 }
 
+export interface CompileAllOpts extends ProxyTaskArgs.t {
+	json: boolean;
+}
+
 export interface TestOpts extends RequestArgs.t {
 	task?: string;
 	sourceFile?: string;
 }
 
-export type IntersectionOpts = LigoOpts & CompileOpts & TestOpts;
+export type IntersectionOpts = LigoOpts & CompileOpts & CompileAllOpts & TestOpts;
 
-type UnionOpts = LigoOpts | CompileOpts | TestOpts;
+type UnionOpts = LigoOpts | CompileOpts | CompileAllOpts | TestOpts;
 
 // Should point to the latest stable version, so it needs to be updated as part of our release process.
 const LIGO_DEFAULT_IMAGE = 'ligolang/ligo:0.57.0';

--- a/taqueria-plugin-ligo/compile-all.ts
+++ b/taqueria-plugin-ligo/compile-all.ts
@@ -1,0 +1,28 @@
+import { sendErr, sendJsonRes } from '@taqueria/node-sdk';
+import glob from 'fast-glob';
+import { readFile } from 'fs/promises';
+import { CompileAllOpts as Opts, CompileOpts, getInputFilename } from './common';
+import { compileOneContract, TableRow } from './compile';
+
+const isMainContract = (parsedArgs: Opts, contactFilename: string): Promise<boolean> =>
+	readFile(getInputFilename(parsedArgs, contactFilename), 'utf8')
+		.then(data => /(const|let|function)\s+main/.test(data));
+
+const compileAll = async (parsedArgs: Opts): Promise<void> => {
+	let p: Promise<TableRow[]>[] = [];
+
+	const contractFilenames = await glob(
+		['**/*.ligo', '**/*.mligo', '**/*.jsligo'],
+		{ cwd: parsedArgs.config.contractsDir, absolute: false },
+	);
+
+	for (const filename of contractFilenames) {
+		if (await isMainContract(parsedArgs, filename)) {
+			p.push(compileOneContract(parsedArgs as CompileOpts, filename));
+		}
+	}
+
+	return Promise.all(p).then(tables => tables.flat()).then(sendJsonRes).catch(err => sendErr(err, false));
+};
+
+export default compileAll;

--- a/taqueria-plugin-ligo/compile-all.ts
+++ b/taqueria-plugin-ligo/compile-all.ts
@@ -2,7 +2,7 @@ import { sendErr, sendJsonRes } from '@taqueria/node-sdk';
 import glob from 'fast-glob';
 import { readFile } from 'fs/promises';
 import { CompileAllOpts as Opts, CompileOpts, getInputFilename } from './common';
-import { compileOneContract, TableRow } from './compile';
+import { compileContractWithStorageAndParameter, TableRow } from './compile';
 
 const isMainContract = (parsedArgs: Opts, contactFilename: string): Promise<boolean> =>
 	readFile(getInputFilename(parsedArgs, contactFilename), 'utf8')
@@ -18,7 +18,7 @@ const compileAll = async (parsedArgs: Opts): Promise<void> => {
 
 	for (const filename of contractFilenames) {
 		if (await isMainContract(parsedArgs, filename)) {
-			p.push(compileOneContract(parsedArgs as CompileOpts, filename));
+			p.push(compileContractWithStorageAndParameter(parsedArgs as CompileOpts, filename));
 		}
 	}
 

--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -3,7 +3,7 @@ import { access, readFile, writeFile } from 'fs/promises';
 import { basename, extname, join } from 'path';
 import { CompileOpts as Opts, emitExternalError, getInputFilename, getLigoDockerImage } from './common';
 
-type TableRow = { contract: string; artifact: string };
+export type TableRow = { contract: string; artifact: string };
 
 export type ExprKind = 'storage' | 'default_storage' | 'parameter';
 
@@ -272,8 +272,7 @@ const mergeArtifactsOutput = (sourceFile: string) =>
 		}];
 	};
 
-const compile = (parsedArgs: Opts): Promise<void> => {
-	const sourceFile = parsedArgs.sourceFile!;
+export const compileOneContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow[]> => {
 	let p: Promise<TableRow[]>;
 	if (isStorageListFile(sourceFile)) p = compileExprs(parsedArgs, sourceFile, 'storage');
 	else if (isParameterListFile(sourceFile)) p = compileExprs(parsedArgs, sourceFile, 'parameter');
@@ -283,8 +282,12 @@ const compile = (parsedArgs: Opts): Promise<void> => {
 			`${sourceFile} doesn't have a valid LIGO extension ('.ligo', '.religo', '.mligo' or '.jsligo')`,
 		);
 	}
-	return p.then(sendJsonRes).catch(err => sendErr(err, false));
+	return p;
 };
+
+const compile = (parsedArgs: Opts): Promise<void> =>
+	compileOneContract(parsedArgs, parsedArgs.sourceFile)
+		.then(sendJsonRes).catch(err => sendErr(err, false));
 
 export default compile;
 export const ___TEST___ = {

--- a/taqueria-plugin-ligo/compile.ts
+++ b/taqueria-plugin-ligo/compile.ts
@@ -206,7 +206,10 @@ const initContentForParameter = (sourceFile: string): string => {
 	return linkToContract + instruction + syntax;
 };
 
-const compileContractWithStorageAndParameter = async (parsedArgs: Opts, sourceFile: string): Promise<TableRow[]> => {
+export const compileContractWithStorageAndParameter = async (
+	parsedArgs: Opts,
+	sourceFile: string,
+): Promise<TableRow[]> => {
 	const contractCompileResult = await compileContract(parsedArgs, sourceFile);
 	if (contractCompileResult.artifact === COMPILE_ERR_MSG) return [contractCompileResult];
 
@@ -272,7 +275,8 @@ const mergeArtifactsOutput = (sourceFile: string) =>
 		}];
 	};
 
-export const compileOneContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow[]> => {
+const compile = (parsedArgs: Opts): Promise<void> => {
+	const sourceFile = parsedArgs.sourceFile!;
 	let p: Promise<TableRow[]>;
 	if (isStorageListFile(sourceFile)) p = compileExprs(parsedArgs, sourceFile, 'storage');
 	else if (isParameterListFile(sourceFile)) p = compileExprs(parsedArgs, sourceFile, 'parameter');
@@ -282,12 +286,8 @@ export const compileOneContract = (parsedArgs: Opts, sourceFile: string): Promis
 			`${sourceFile} doesn't have a valid LIGO extension ('.ligo', '.religo', '.mligo' or '.jsligo')`,
 		);
 	}
-	return p;
+	return p.then(sendJsonRes).catch(err => sendErr(err, false));
 };
-
-const compile = (parsedArgs: Opts): Promise<void> =>
-	compileOneContract(parsedArgs, parsedArgs.sourceFile)
-		.then(sendJsonRes).catch(err => sendErr(err, false));
 
 export default compile;
 export const ___TEST___ = {

--- a/taqueria-plugin-ligo/index.ts
+++ b/taqueria-plugin-ligo/index.ts
@@ -41,6 +41,21 @@ Plugin.create(i18n => ({
 			encoding: 'json',
 		}),
 		Task.create({
+			task: 'compile-all',
+			command: 'compile-all',
+			description:
+				'Compile all main smart contracts written in a LIGO syntax to Michelson code, along with their associated storage/parameter list files if they are found',
+			options: [
+				Option.create({
+					flag: 'json',
+					boolean: true,
+					description: 'Emit JSON-encoded Michelson',
+				}),
+			],
+			handler: 'proxy',
+			encoding: 'json',
+		}),
+		Task.create({
 			task: 'test',
 			command: 'test <sourceFile>',
 			description: 'Test a smart contract written in LIGO',

--- a/taqueria-plugin-ligo/main.ts
+++ b/taqueria-plugin-ligo/main.ts
@@ -1,6 +1,7 @@
 import { RequestArgs, sendAsyncErr, sendAsyncRes } from '@taqueria/node-sdk';
 import { getLigoDockerImage, IntersectionOpts as Opts } from './common';
 import compile from './compile';
+import compileAll from './compile-all';
 import ligo from './ligo';
 import test from './test';
 
@@ -11,6 +12,8 @@ const main = (parsedArgs: RequestArgs.t): Promise<void> => {
 			return ligo(unsafeOpts);
 		case 'compile':
 			return compile(unsafeOpts);
+		case 'compile-all':
+			return compileAll(unsafeOpts);
 		case 'test':
 			return test(parsedArgs);
 		case 'get-image':

--- a/taqueria-plugin-smartpy/README.md
+++ b/taqueria-plugin-smartpy/README.md
@@ -47,6 +47,16 @@ Expression compilation targets in SmartPy produce only the expression Michelson 
 
 The `--json` flag will make the task emit JSON-encoded Michelson instead of pure Michelson `.tz`
 
+## The `taq compile-all` Task
+
+Basic usage is:
+
+```shell
+taq compile-all
+```
+
+It works just like the `compile` task but it compiles all contracts with at least one SmartPy compilation target.
+
 ## The `taq test` Task
 
 Basic usage is:

--- a/taqueria-plugin-smartpy/_readme.eta
+++ b/taqueria-plugin-smartpy/_readme.eta
@@ -51,6 +51,16 @@ Expression compilation targets in SmartPy produce only the expression Michelson 
 
 The `--json` flag will make the task emit JSON-encoded Michelson instead of pure Michelson `.tz`
 
+## The `taq compile-all` Task
+
+Basic usage is:
+
+```shell
+taq compile-all
+```
+
+It works just like the `compile` task but it compiles all contracts with at least one SmartPy compilation target.
+
 ## The `taq test` Task
 
 Basic usage is:

--- a/taqueria-plugin-smartpy/common.ts
+++ b/taqueria-plugin-smartpy/common.ts
@@ -8,13 +8,17 @@ export interface CompileOpts extends ProxyTaskArgs.t {
 	json: boolean;
 }
 
+export interface CompileAllOpts extends ProxyTaskArgs.t {
+	json: boolean;
+}
+
 export interface TestOpts extends ProxyTaskArgs.t {
 	sourceFile: string;
 }
 
-export type IntersectionOpts = CompileOpts & TestOpts;
+export type IntersectionOpts = CompileOpts & CompileAllOpts & TestOpts;
 
-type UnionOpts = CompileOpts | TestOpts;
+type UnionOpts = CompileOpts | CompileAllOpts | TestOpts;
 
 // Should point to the latest stable version, so it needs to be updated as part of our release process.
 const SMARTPY_DEFAULT_VERSION = 'v0.16.0';

--- a/taqueria-plugin-smartpy/compile.ts
+++ b/taqueria-plugin-smartpy/compile.ts
@@ -165,7 +165,7 @@ const getCompileContractCmd = (parsedArgs: Opts, sourceFile: string): string => 
 	return `${getSmartPyCli()} compile ${getInputFilename(parsedArgs, sourceFile)} ${outputDir} ${booleanFlags}`;
 };
 
-const compileContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =>
+export const compileContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =>
 	getArch()
 		.then(() => installSmartPyCliIfNotExist())
 		.then(() => getCompileContractCmd(parsedArgs, sourceFile))
@@ -187,11 +187,8 @@ const compileContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow
 			};
 		});
 
-export const compileOneContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =>
-	compileContract(parsedArgs, sourceFile);
-
 const compile = (parsedArgs: Opts): Promise<void> =>
-	compileOneContract(parsedArgs, addPyExtensionIfMissing(parsedArgs.sourceFile))
+	compileContract(parsedArgs, addPyExtensionIfMissing(parsedArgs.sourceFile))
 		.then(result => [result])
 		.then(sendJsonRes)
 		.catch(err => sendAsyncErr(err, false));

--- a/taqueria-plugin-smartpy/compile.ts
+++ b/taqueria-plugin-smartpy/compile.ts
@@ -11,7 +11,7 @@ import {
 	installSmartPyCliIfNotExist,
 } from './common';
 
-type TableRow = { contract: string; artifact: string };
+export type TableRow = { contract: string; artifact: string };
 
 const COMPILE_ERR_MSG: string = 'Not compiled';
 
@@ -187,12 +187,13 @@ const compileContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow
 			};
 		});
 
-const compile = (parsedArgs: Opts): Promise<void> => {
-	const sourceFile = addPyExtensionIfMissing(parsedArgs.sourceFile);
-	return compileContract(parsedArgs, sourceFile)
+export const compileOneContract = (parsedArgs: Opts, sourceFile: string): Promise<TableRow> =>
+	compileContract(parsedArgs, sourceFile);
+
+const compile = (parsedArgs: Opts): Promise<void> =>
+	compileOneContract(parsedArgs, addPyExtensionIfMissing(parsedArgs.sourceFile))
 		.then(result => [result])
 		.then(sendJsonRes)
 		.catch(err => sendAsyncErr(err, false));
-};
 
 export default compile;

--- a/taqueria-plugin-smartpy/compileAll.ts
+++ b/taqueria-plugin-smartpy/compileAll.ts
@@ -1,0 +1,28 @@
+import { sendAsyncErr, sendJsonRes } from '@taqueria/node-sdk';
+import glob from 'fast-glob';
+import { readFile } from 'fs/promises';
+import { CompileAllOpts as Opts, CompileOpts, getInputFilename } from './common';
+import { compileOneContract, TableRow } from './compile';
+
+const contractHasCompTarget = (parsedArgs: Opts, contactFilename: string): Promise<boolean> =>
+	readFile(getInputFilename(parsedArgs, contactFilename), 'utf8')
+		.then(data => /add_(expression_)?compilation_target\s*\(\s*['"][^'"]+['"]/.test(data));
+
+const compileAll = async (parsedArgs: Opts): Promise<void> => {
+	let p: Promise<TableRow>[] = [];
+
+	const contractFilenames = await glob(
+		['**/*.py'],
+		{ cwd: parsedArgs.config.contractsDir, absolute: false },
+	);
+
+	for (const filename of contractFilenames) {
+		if (await contractHasCompTarget(parsedArgs, filename)) {
+			p.push(compileOneContract(parsedArgs as CompileOpts, filename));
+		}
+	}
+
+	return Promise.all(p).then(sendJsonRes).catch(err => sendAsyncErr(err, false));
+};
+
+export default compileAll;

--- a/taqueria-plugin-smartpy/compileAll.ts
+++ b/taqueria-plugin-smartpy/compileAll.ts
@@ -2,7 +2,7 @@ import { sendAsyncErr, sendJsonRes } from '@taqueria/node-sdk';
 import glob from 'fast-glob';
 import { readFile } from 'fs/promises';
 import { CompileAllOpts as Opts, CompileOpts, getInputFilename } from './common';
-import { compileOneContract, TableRow } from './compile';
+import { compileContract, TableRow } from './compile';
 
 const contractHasCompTarget = (parsedArgs: Opts, contactFilename: string): Promise<boolean> =>
 	readFile(getInputFilename(parsedArgs, contactFilename), 'utf8')
@@ -18,7 +18,7 @@ const compileAll = async (parsedArgs: Opts): Promise<void> => {
 
 	for (const filename of contractFilenames) {
 		if (await contractHasCompTarget(parsedArgs, filename)) {
-			p.push(compileOneContract(parsedArgs as CompileOpts, filename));
+			p.push(compileContract(parsedArgs as CompileOpts, filename));
 		}
 	}
 

--- a/taqueria-plugin-smartpy/index.ts
+++ b/taqueria-plugin-smartpy/index.ts
@@ -23,6 +23,21 @@ Plugin.create(i18n => ({
 			],
 		}),
 		Task.create({
+			task: 'compile-all',
+			command: 'compile-all',
+			description:
+				'Compile all SmartPy smart contracts with at least one SmartPy compilation target to Michelson code, along with their associated storage values, per compilation targets, and some expressions per expression compilation targets',
+			handler: 'proxy',
+			encoding: 'json',
+			options: [
+				Option.create({
+					flag: 'json',
+					boolean: true,
+					description: 'Emit JSON-encoded Michelson',
+				}),
+			],
+		}),
+		Task.create({
 			task: 'test',
 			command: 'test <sourceFile>',
 			description: 'Test a smart contract written in SmartPy',

--- a/taqueria-plugin-smartpy/main.ts
+++ b/taqueria-plugin-smartpy/main.ts
@@ -1,6 +1,7 @@
 import { RequestArgs, sendAsyncErr } from '@taqueria/node-sdk';
 import { IntersectionOpts as Opts } from './common';
 import compile from './compile';
+import compileAll from './compileAll';
 import test from './test';
 
 const main = (parsedArgs: RequestArgs.t): Promise<void> => {
@@ -8,6 +9,8 @@ const main = (parsedArgs: RequestArgs.t): Promise<void> => {
 	switch (unsafeArgs.task) {
 		case 'compile':
 			return compile(unsafeArgs);
+		case 'compile-all':
+			return compileAll(unsafeArgs);
 		case 'test':
 			return test(unsafeArgs);
 		default:


### PR DESCRIPTION
# 🌮 Taqueria PR

Fixes #1576

## 🪁 Description

Implemented `taq compile-all` for the LIGO and SmartPy plugin which compiles all LIGO main contracts (contracts with a main function) and all SmartPy contracts with at least one SmartPy compilation target, respectively.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

_Please include a summary of the changes to the codebase._ _Please also include relevant motivation and context for the change_
_(e.g. what was the existing behaviour, why did it break, etc.)_

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [ ] 🛠️ Fix ➾
- [x] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
