### PR TITLE
🛠️ Fix ➾ Make compile and compile-all work when users exec them in contracts dir

### DIFF
--- a/taqueria-plugin-ligo/common.ts
+++ b/taqueria-plugin-ligo/common.ts
@@ -31,7 +31,10 @@ const LIGO_IMAGE_ENV_VAR = 'TAQ_LIGO_IMAGE';
 
 export const getLigoDockerImage = (): string => getDockerImage(LIGO_DEFAULT_IMAGE, LIGO_IMAGE_ENV_VAR);
 
-export const getInputFilename = (parsedArgs: UnionOpts, sourceFile: string): string =>
+export const getInputFilenameAbsPath = (parsedArgs: UnionOpts, sourceFile: string): string =>
+	join(parsedArgs.config.projectDir, parsedArgs.config.contractsDir ?? 'contracts', sourceFile);
+
+export const getInputFilenameRelPath = (parsedArgs: UnionOpts, sourceFile: string): string =>
 	join(parsedArgs.config.contractsDir ?? 'contracts', sourceFile);
 
 export const emitExternalError = (err: unknown, sourceFile: string): void => {

--- a/taqueria-plugin-ligo/compile-all.ts
+++ b/taqueria-plugin-ligo/compile-all.ts
@@ -1,19 +1,20 @@
 import { sendErr, sendJsonRes } from '@taqueria/node-sdk';
 import glob from 'fast-glob';
 import { readFile } from 'fs/promises';
-import { CompileAllOpts as Opts, CompileOpts, getInputFilename } from './common';
+import { join } from 'path';
+import { CompileAllOpts as Opts, CompileOpts, getInputFilenameAbsPath } from './common';
 import { compileContractWithStorageAndParameter, TableRow } from './compile';
 
 const isMainContract = (parsedArgs: Opts, contactFilename: string): Promise<boolean> =>
-	readFile(getInputFilename(parsedArgs, contactFilename), 'utf8')
+	readFile(getInputFilenameAbsPath(parsedArgs, contactFilename), 'utf8')
 		.then(data => /(const|let|function)\s+main/.test(data));
 
 const compileAll = async (parsedArgs: Opts): Promise<void> => {
 	let p: Promise<TableRow[]>[] = [];
 
 	const contractFilenames = await glob(
-		['**/*.ligo', '**/*.mligo', '**/*.jsligo'],
-		{ cwd: parsedArgs.config.contractsDir, absolute: false },
+		['**/*.ligo', '**/*.religo', '**/*.mligo', '**/*.jsligo'],
+		{ cwd: join(parsedArgs.config.projectDir, parsedArgs.config.contractsDir ?? 'contracts'), absolute: false },
 	);
 
 	for (const filename of contractFilenames) {

--- a/taqueria-plugin-ligo/test.ts
+++ b/taqueria-plugin-ligo/test.ts
@@ -1,5 +1,5 @@
 import { execCmd, getArch, sendAsyncErr, sendJsonRes, sendWarn } from '@taqueria/node-sdk';
-import { emitExternalError, getInputFilename, getLigoDockerImage, TestOpts as Opts } from './common';
+import { emitExternalError, getInputFilenameRelPath, getLigoDockerImage, TestOpts as Opts } from './common';
 
 type TableRow = { contract: string; testResults: string };
 
@@ -8,7 +8,7 @@ const getTestContractCmd = (parsedArgs: Opts, sourceFile: string): string => {
 	if (!projectDir) throw `No project directory provided`;
 	const baseCmd =
 		`DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -v \"${projectDir}\":/project -w /project -u $(id -u):$(id -g) ${getLigoDockerImage()} run test`;
-	const inputFile = getInputFilename(parsedArgs, sourceFile);
+	const inputFile = getInputFilenameRelPath(parsedArgs, sourceFile);
 	const cmd = `${baseCmd} ${inputFile}`;
 	return cmd;
 };

--- a/taqueria-plugin-smartpy/common.ts
+++ b/taqueria-plugin-smartpy/common.ts
@@ -77,10 +77,10 @@ const removeExt = (path: string): string => {
 };
 
 export const getInputFilename = (parsedArgs: UnionOpts, sourceFile: string): string =>
-	join(getContractsDir(parsedArgs), sourceFile);
+	join(parsedArgs.config.projectDir, getContractsDir(parsedArgs), sourceFile);
 
 export const getCompilationTargetsDirname = (parsedArgs: UnionOpts, sourceFile: string): string =>
-	join(getArtifactsDir(parsedArgs), SMARTPY_ARTIFACTS_DIR, removeExt(sourceFile));
+	join(parsedArgs.config.projectDir, getArtifactsDir(parsedArgs), SMARTPY_ARTIFACTS_DIR, removeExt(sourceFile));
 
 export const installSmartPyCliIfNotExist = () =>
 	access(getSmartPyCli())

--- a/taqueria-plugin-smartpy/compile.ts
+++ b/taqueria-plugin-smartpy/compile.ts
@@ -20,7 +20,7 @@ const isOutputFormatJSON = (parsedArgs: Opts): boolean => parsedArgs.json;
 const getOutputContractFilename = (parsedArgs: Opts, sourceFile: string): string => {
 	const outputFile = basename(sourceFile, extname(sourceFile));
 	const ext = isOutputFormatJSON(parsedArgs) ? '.json' : '.tz';
-	return join(getArtifactsDir(parsedArgs), `${outputFile}${ext}`);
+	return join(parsedArgs.config.projectDir, getArtifactsDir(parsedArgs), `${outputFile}${ext}`);
 };
 
 const getOutputStorageFilename = (
@@ -34,14 +34,14 @@ const getOutputStorageFilename = (
 	const storageName = isDefaultStorage
 		? `${outputFile}.default_storage${ext}`
 		: `${outputFile}.storage.${compilationTargetName}${ext}`;
-	return join(getArtifactsDir(parsedArgs), storageName);
+	return join(parsedArgs.config.projectDir, getArtifactsDir(parsedArgs), storageName);
 };
 
 const getOutputExprFilename = (parsedArgs: Opts, sourceFile: string, compilationTargetName: string): string => {
 	const outputFile = basename(sourceFile, extname(sourceFile));
 	const ext = isOutputFormatJSON(parsedArgs) ? '.json' : '.tz';
 	const exprName = `${outputFile}.expression.${compilationTargetName}${ext}`;
-	return join(getArtifactsDir(parsedArgs), exprName);
+	return join(parsedArgs.config.projectDir, getArtifactsDir(parsedArgs), exprName);
 };
 
 const getCompilationTargetNames = (

--- a/taqueria-plugin-smartpy/compileAll.ts
+++ b/taqueria-plugin-smartpy/compileAll.ts
@@ -1,6 +1,7 @@
-import { sendAsyncErr, sendJsonRes } from '@taqueria/node-sdk';
+import { getContractsDir, sendAsyncErr, sendJsonRes } from '@taqueria/node-sdk';
 import glob from 'fast-glob';
 import { readFile } from 'fs/promises';
+import { join } from 'path';
 import { CompileAllOpts as Opts, CompileOpts, getInputFilename } from './common';
 import { compileContract, TableRow } from './compile';
 
@@ -13,7 +14,7 @@ const compileAll = async (parsedArgs: Opts): Promise<void> => {
 
 	const contractFilenames = await glob(
 		['**/*.py'],
-		{ cwd: parsedArgs.config.contractsDir, absolute: false },
+		{ cwd: join(parsedArgs.config.projectDir, getContractsDir(parsedArgs)), absolute: false },
 	);
 
 	for (const filename of contractFilenames) {

--- a/tests/e2e/smartpy-plugin-e2e-tests.spec.ts
+++ b/tests/e2e/smartpy-plugin-e2e-tests.spec.ts
@@ -29,8 +29,12 @@ describe('SmartPy Plugin E2E Testing for Taqueria CLI', () => {
 		await writeFile('./test-project/contracts/hello-tacos.py', py_file);
 
 		const { stdout } = await execute('taq', 'compile hello-tacos.py', './test-project');
-		expect(stdout).toEqual(expect.arrayContaining(['│ hello-tacos.py │ artifacts/hello-tacos.tz                 │']));
-		expect(stdout).toEqual(expect.arrayContaining(['│                │ artifacts/hello-tacos.default_storage.tz │']));
+		expect(stdout).toEqual(
+			expect.arrayContaining(['│ hello-tacos.py │ {{base}}/test-project/artifacts/hello-tacos.tz                 │']),
+		);
+		expect(stdout).toEqual(
+			expect.arrayContaining(['│                │ {{base}}/test-project/artifacts/hello-tacos.default_storage.tz │']),
+		);
 
 		await exists(`./test-project/artifacts/hello-tacos.tz`);
 		await exists(`./test-project/artifacts/hello-tacos.default_storage.tz`);


### PR DESCRIPTION
# 🌮 Taqueria PR

Fixes #1764

## 🪁 Description

LIGO and SmartPy compile and compile-all only worked when executed in the root directory of a TAQ project. Now users can execute them in any subdirectory within root.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

_Please include a summary of the changes to the codebase._ _Please also include relevant motivation and context for the change_
_(e.g. what was the existing behaviour, why did it break, etc.)_

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [x] 🛠️ Fix ➾
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
