### PR TITLE
👷 Refactor ➾ Added V2 API for the toolkit

### DIFF
--- a/taqueria-protocol/scripts/post-ts-to-zod.ts
+++ b/taqueria-protocol/scripts/post-ts-to-zod.ts
@@ -12,6 +12,7 @@ const PASSTHROUGH_TYPES = [
 	'ProxyTaskArgs',
 	'ProxyTemplateArgs',
 	'SanitizedArgs',
+	'ConfigEnvironmentFileV2',
 ];
 
 /**

--- a/taqueria-protocol/types-config-files.ts
+++ b/taqueria-protocol/types-config-files.ts
@@ -250,7 +250,6 @@ export const transformConfigToConfigFileV2 = (config: Config): ConfigFileSetV2 =
 
 // FileV2 to Object
 export const transformConfigFileV2ToConfig = (configFileSetV2: ConfigFileSetV2): Config => {
-	debugger;
 	const {
 		config: configFileV2,
 		environments: environmentFilesV2,

--- a/taqueria-protocol/types-config-files.ts
+++ b/taqueria-protocol/types-config-files.ts
@@ -93,7 +93,7 @@ const removeUndefinedFields = <T>(x: T): T => {
  * This function should be sealed while the transformConfigToConfigFileV2
  * will change interatively to become move like V2
  */
-const transformConfigFileV1ToConfigFileSetV2 = (configFileV1: ConfigFileV1): ConfigFileSetV2 => {
+export const transformConfigFileV1ToConfigFileSetV2 = (configFileV1: ConfigFileV1): ConfigFileSetV2 => {
 	const config = configFileV1;
 	const configFileV2: ConfigFileV2 = {
 		version: `v2`,
@@ -145,7 +145,7 @@ const transformConfigFileV1ToConfigFileSetV2 = (configFileV1: ConfigFileV1): Con
 };
 
 // Object to FileV2
-const transformConfigToConfigFileV2 = (config: Config): ConfigFileSetV2 => {
+export const transformConfigToConfigFileV2 = (config: Config): ConfigFileSetV2 => {
 	const configFileV2: ConfigFileV2 = {
 		version: `v2`,
 		language: config.language,

--- a/taqueria-toolkit/TaqError.ts
+++ b/taqueria-toolkit/TaqError.ts
@@ -1,0 +1,5 @@
+export class TaqError extends Error {
+	public isTaqError = true;
+}
+export const isTaqError = (err: unknown): err is TaqError =>
+	typeof err === 'object' && (err as object).hasOwnProperty('isTaqError');

--- a/taqueria-toolkit/index.ts
+++ b/taqueria-toolkit/index.ts
@@ -91,7 +91,9 @@ export const getConfigAsV1 = (env: Record<string, string | undefined>, prefix = 
 	} catch (err) {
 		throw isTaqError(err)
 			? err
-			: new TaqError('todo'); // TODO
+			: new TaqError(
+				`Something went wrong trying to parse your configuration. Please report this to the Taqueria Developers: ${err}`,
+			);
 	}
 };
 
@@ -127,7 +129,9 @@ export function getConfigV2(
 	} catch (err) {
 		throw isTaqError(err)
 			? err
-			: new TaqError('todo'); // TODO
+			: new TaqError(
+				`Something went wrong trying to parse your configuration. Please report this to the Taqueria Developers: ${err}`,
+			);
 	}
 }
 

--- a/taqueria-toolkit/index.ts
+++ b/taqueria-toolkit/index.ts
@@ -110,7 +110,7 @@ export function getConfigV2(
 		if (!rawConfig.version || rawConfig.version.toLowerCase() === 'v1') {
 			const configV1 = Config.from(rawConfig);
 			return transform.transformConfigToConfigFileV2(configV1);
-		} else if (rawConfig.version.tolowerCase() === 'v2') {
+		} else if (rawConfig.version.toLowerCase() === 'v2') {
 			const configV2 = ConfigFileV2.from(rawConfig);
 			const environments = Object.keys(configV2.environments ?? {}).reduce(
 				(retval, envName) => ({ ...retval, [envName]: getEnvironmentConfig(envName) }),

--- a/taqueria-toolkit/v1.ts
+++ b/taqueria-toolkit/v1.ts
@@ -1,0 +1,16 @@
+import * as Config from '@taqueria/protocol/Config';
+import * as Environment from '@taqueria/protocol/Environment';
+
+export const getCurrentEnv = (config: Config.t): Environment.t | undefined => {
+	const currentEnv = config?.environment?.default ? config.environment.default as string : 'development';
+	return config.environment && config.environment[currentEnv]
+		? config.environment[currentEnv] as Environment.t | undefined
+		: undefined;
+};
+
+export const getAliasAddress = (config: any, alias: string): string => {
+	const currentEnv = getCurrentEnv(config);
+	if (currentEnv?.aliases?.[alias]?.address) return currentEnv.aliases[alias].address;
+	alert(`Address for alias, ${alias}, is missing. Please deploy a contract with such alias`);
+	return '';
+};

--- a/taqueria-toolkit/v2.ts
+++ b/taqueria-toolkit/v2.ts
@@ -1,0 +1,30 @@
+// TODO: Write a comprehensive API for V2
+import * as ConfigEnvironmentFileV2 from '@taqueria/protocol/ConfigEnvironmentFileV2';
+import * as Config from '@taqueria/protocol/ConfigFileV2';
+import { ConfigFileSetV2 } from '@taqueria/protocol/types-config-files';
+import { isTaqError, TaqError } from './TaqError';
+
+type ExpandedEnv = Record<string, unknown> & ConfigEnvironmentFileV2.t & { __type: 'expandedEnv' };
+export function getEnv(envName: string, settings: ConfigFileSetV2): ExpandedEnv {
+	const mainEnv = settings.config.environments?.[envName];
+	if (mainEnv) {
+		return {
+			...mainEnv,
+			...settings.environments[envName],
+		} as ExpandedEnv;
+	}
+	throw new TaqError(`There is no environment configured called ${envName}`);
+}
+
+export const getCurrentEnv = (settings: ConfigFileSetV2) => {
+	if (settings.config.environmentDefault) {
+		return getEnv(settings.config.environmentDefault, settings);
+	}
+	throw new TaqError(
+		`No default environment has been configured. Please set the "environmentDefault" property in your .taq/config.json.`,
+	);
+};
+
+export function getContractAddress(contractName: string, env: ExpandedEnv) {
+	return env.contracts?.[contractName]?.address;
+}


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Previously, the API of the toolkit included two functions that would only work when given Config V1 objects.

This PR adds a V2 namespace for functions that work with Config V2 objects.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

- In my last refactor, I introduced a `loadFromEnv` function which has been renamed to `withEnv`, made private, and used internally by two new public functions, `getConfigV1` and `getConfigV2`. These will return a representation of the project's form in either V1 or V2 respectfully, regardless of what version the actual config file is using. This facilitates backwards and frontwards compatibility.
- Introduces the V2 module, which is the start of an API for working with projects using the V2 config. This API is limited to just three functions for now, but we can flesh this out later.

NOTE: this toolkit and the V2 API will be used in the upcoming taco-shop scaffold refactor.

## 🎢 Test Plan

Testing against the taco-shop scaffold.