### PR TITLE
Rollback TzKt to Ecad images

### DIFF
--- a/taqueria-plugin-core/clean.ts
+++ b/taqueria-plugin-core/clean.ts
@@ -4,7 +4,7 @@ const ECAD_FLEXTESA_IMAGE = 'ghcr.io/ecadlabs/taqueria-flextesa';
 const FLEXTESA_IMAGE = 'oxheadalpha/flextesa';
 const LIGO_IMAGE = 'ligolang/ligo';
 const ARCHETYPE_IMAGE = 'completium/archetype';
-const ECAD_TZKT_IMAGE = 'alirezahaghshenas/tzkt';
+const ECAD_TZKT_IMAGE = 'ghcr.io/ecadlabs/tzkt';
 
 const getDockerImageIdsCmd = (): string => {
 	const images = [ECAD_FLEXTESA_IMAGE, FLEXTESA_IMAGE, LIGO_IMAGE, ARCHETYPE_IMAGE, ECAD_TZKT_IMAGE];

--- a/taqueria-plugin-flextesa/tzkt-manager.ts
+++ b/taqueria-plugin-flextesa/tzkt-manager.ts
@@ -5,8 +5,8 @@ import { ValidOpts } from './types';
 
 const getTzKtDockerImages = (opts: ValidOpts) => ({
 	postgres: `postgres:14.5-alpine`,
-	sync: `bakingbad/tzkt-sync:1.11.1`,
-	api: `bakingbad/tzkt-api:1.11.1`,
+	sync: `ghcr.io/ecadlabs/tzkt-sync:v1.11.0-taqueria`,
+	api: `ghcr.io/ecadlabs/tzkt-api:v1.11.0-taqueria`,
 });
 
 export const getTzKtContainerNames = async (sandboxName: string, parsedArgs: ValidOpts) => {


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

TzKt images released by Baking Bad are not running on m1 macs.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Rolled back to the TzKt images maintained by ECAD

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾ 
- [x] 🛠️ Fix ➾ Rolled back to the TzKt images maintained by ECAD
- [ ] ✨ Feature ➾
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
