### PR TITLE
🛠️ Fix ➾ execCmd should always reject with Error instance with stdout and stderr properties

### DIFF
--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -66,9 +66,7 @@ export const execCmd = (cmd: string): LikeAPromise<StdIO, ExecException & { stdo
 		const escapedCmd = cmd.replaceAll(/"/gm, '\\"');
 		exec(`sh -c "${escapedCmd}"`, (err, stdout, stderr) => {
 			if (err) {
-				typeof err === 'string'
-					? reject({ message: err, stderr, stdout })
-					: reject(Object.assign({ message: stderr, stderr, stdout }, err));
+				reject(toErrorWithProps(err, { stderr, stdout }));
 			} else {
 				resolve({
 					stdout,
@@ -77,6 +75,15 @@ export const execCmd = (cmd: string): LikeAPromise<StdIO, ExecException & { stdo
 			}
 		});
 	});
+
+export const toErrorWithProps = (message: string | Error, props: Record<string, unknown>): Error => {
+	const err = message instanceof Error ? message : new Error(message);
+	const retval = Object.assign(props, err);
+
+	// Note, retval looses its prototype using Object.assign. Same thing with using spread operator.
+	retval.__proto__ = Error.prototype;
+	return err;
+};
 
 export const execCommandWithoutWrapping = (cmd: string): LikeAPromise<StdIO, ExecException> =>
 	new Promise((resolve, reject) => {


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

There was a change made to execCmd's rejection value to include stderr and stdout properties. However, this broke tasks which explicitly checked whether the rejection value was an instanceof the Error prototype.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

I've modified the execCmd function in such that the rejection value is always an Error instance, but with stderr and stdout added as runtime properties.

This assures that the code in the ligo plugin's `test` task works as it should:
```
export const emitExternalError = (err: unknown, sourceFile: string): void => {
	sendErr(`\n=== Error messages for ${sourceFile} ===`);
	err instanceof Error ? sendErr(err.message.replace(/Command failed.+?\n/, '')) : sendErr(err as any);
	sendErr(`\n===`);
};
```

It also ensures that the code in the flextesa plugin that is using the stderr property work as well:
```
return execCmd(`docker run --rm ${image} flextesa mini-net --protocol-kind=foobar`)
	.catch(err => {
		const { stderr } = err;
		const protocols = stderr.match(/'[A-Z][a-z]+'/gm) ?? [];
		return Promise.resolve(protocols.map((protocol: string) => protocol.replace(/'/gm, '')));
	});
```