### PR TITLE
🛠️ Fix ➾ bug introduced in toErrorWithProps. Wrong return value.

### DIFF
--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -82,7 +82,7 @@ export const toErrorWithProps = (message: string | Error, props: Record<string, 
 
 	// Note, retval looses its prototype using Object.assign. Same thing with using spread operator.
 	retval.__proto__ = Error.prototype;
-	return err;
+	return retval;
 };
 
 export const execCommandWithoutWrapping = (cmd: string): LikeAPromise<StdIO, ExecException> =>

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -66,7 +66,7 @@ export const execCmd = (cmd: string): LikeAPromise<StdIO, ExecException & { stdo
 		const escapedCmd = cmd.replaceAll(/"/gm, '\\"');
 		exec(`sh -c "${escapedCmd}"`, (err, stdout, stderr) => {
 			if (err) {
-				reject(toErrorWithProps(err, { stderr, stdout }));
+				reject(toExecErr(err, { stderr, stdout }));
 			} else {
 				resolve({
 					stdout,
@@ -75,13 +75,15 @@ export const execCmd = (cmd: string): LikeAPromise<StdIO, ExecException & { stdo
 			}
 		});
 	});
-
-export const toErrorWithProps = (message: string | Error, props: Record<string, unknown>): Error => {
+type ExecErrProps = {
+	stderr: string;
+	stdout: string;
+};
+export const toExecErr = (message: string | Error, props: ExecErrProps): Error & ExecErrProps => {
 	const err = message instanceof Error ? message : new Error(message);
-	const retval = Object.assign(props, err);
-
-	// Note, retval looses its prototype using Object.assign. Same thing with using spread operator.
-	retval.__proto__ = Error.prototype;
+	const retval = err as unknown as Error & ExecErrProps;
+	retval.stderr = props.stderr;
+	retval.stdout = props.stdout;
 	return retval;
 };
 


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

When fixing a previous bug, a new one was introduced. I had made a typo and returned the wrong return value, returning the input value instead of the desired output value.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🦀 Automated tests have been written and added to this PR

## 🛩️ Summary of Changes

In toErrorwithProps, return `retval` - not `err`.