### PR TITLE
Fix hyperlink to flextesa plugin documentation

### DIFF
--- a/website/docs/config/networks.mdx
+++ b/website/docs/config/networks.mdx
@@ -3,7 +3,7 @@ title: Testnet and Mainnet Configuration
 ---
 
 :::note
-This document details the configuration and use of Tezos testnets and mainnet. If you are looking for information on running or originating to a sandbox, please see the Flextesa documentation [here](docs/plugins/plugin-flextesa)
+This document details the configuration and use of Tezos testnets and mainnet. If you are looking for information on running or originating to a sandbox, please see [the Flextesa plugin documentation](https://taqueria.io/docs/plugins/plugin-flextesa/).
 :::
 
 ## Introduction


### PR DESCRIPTION
# 🌮 Taqueria PR

PR for https://github.com/ecadlabs/taqueria/issues/1749

## 🪁 Description

This just fixes a 404 on https://taqueria.io/docs/config/networks/.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI

## 🛸 Type of Change

- [x] 🛠️ Fix ➾ 404
