### PR TITLE
🛠️ Fix ➾ Closes #1778, allowing `yes` to all prompts

### DIFF
--- a/taqueria-plugin-mock/package.json
+++ b/taqueria-plugin-mock/package.json
@@ -23,6 +23,6 @@
 	},
 	"homepage": "https://github.com/ecadlabs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.25.16-rc"
+		"@taqueria/node-sdk": "^0.27.16-rc"
 	}
 }

--- a/taqueria-protocol/SanitizedArgs.ts
+++ b/taqueria-protocol/SanitizedArgs.ts
@@ -106,7 +106,21 @@ type RawSetEnvInput = z.infer<typeof setEnvRawSchema>;
 type RawTemplateInput = z.infer<typeof templateRawSchema>;
 
 export const { schemas: generatedSchemas, factory } = createType<RawInput, RawInput>({
-	rawSchema,
+	rawSchema: z.preprocess(
+		unsanitizedArgs => {
+			if (typeof unsanitizedArgs === 'object') {
+				const unparsed: { y?: boolean; yes?: boolean } = { ...unsanitizedArgs };
+				if (unparsed.y) unparsed.yes = unparsed.y;
+				else if (unparsed.yes) unparsed.y = unparsed.yes;
+				return {
+					...unsanitizedArgs,
+					...unparsed,
+				};
+			}
+			return unsanitizedArgs;
+		},
+		rawSchema,
+	),
 	parseErrMsg: 'The arguments provided are invalid',
 	unknownErrMsg: 'Something went wrong parsing the command-line arguments',
 });


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

When a task is prompting for consent, but the end-developer specifies `--yes` or `-y`, then the task should assume `y` to all prompts.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [x] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [x] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Added a preprocess to the SanitizedArgs schema, in such that it checks if either of `y` or `yes` is present.