### PR TITLE
Group Contracts and Artifacts in TreeViews

### DIFF
--- a/taqueria-vscode-extension/src/lib/gui/helpers/GrouppedFileItem.ts
+++ b/taqueria-vscode-extension/src/lib/gui/helpers/GrouppedFileItem.ts
@@ -27,7 +27,7 @@ export class GrouppedFileItem {
 	private static contractChildrenSpecifiers = [/(?<name>.+)\.(?:parameter|storage)List(?<ext>\.(?:m|re|js)?ligo)/];
 	private static artifactChildrenSpecifiers = [
 		/(?<name>.+)\.default_storage(?<ext>\.tz)/,
-		/(?<name>.+)\.(?:storage|parameter|expression)\..*(?<ext>\.tz)/,
+		/(?<name>.+)\.(?:storage|parameter|expression)\..+(?<ext>\.tz)/,
 	];
 
 	static groupAndSortFiles = (

--- a/taqueria-vscode-extension/src/lib/gui/helpers/GrouppedFileItem.ts
+++ b/taqueria-vscode-extension/src/lib/gui/helpers/GrouppedFileItem.ts
@@ -1,0 +1,66 @@
+import path from 'path';
+import * as vscode from 'vscode';
+
+export class GrouppedFileItem {
+	readonly relativePath: string;
+	readonly isChild: boolean;
+	readonly expectedParentName: string | undefined;
+
+	constructor(public readonly uri: vscode.Uri, folder: string, patterns: RegExp[]) {
+		this.relativePath = path.relative(folder, uri.path);
+		const result = GrouppedFileItem.getFirstMatch(this.relativePath, patterns);
+		if (result) {
+			this.expectedParentName = `${result.groups?.name}${result.groups?.ext}`;
+			this.isChild = true;
+		} else {
+			this.isChild = false;
+			this.expectedParentName = undefined;
+		}
+	}
+
+	children: GrouppedFileItem[] = [];
+
+	toString() {
+		return this.uri.toString();
+	}
+
+	private static contractChildrenSpecifiers = [/(?<name>.+)\.(?:parameter|storage)List(?<ext>\.(?:m|re|js)?ligo)/];
+	private static artifactChildrenSpecifiers = [
+		/(?<name>.+)\.default_storage(?<ext>\.tz)/,
+		/(?<name>.+)\.(?:storage|parameter|expression)\..*(?<ext>\.tz)/,
+	];
+
+	static groupAndSortFiles = (
+		folder: string,
+		files: vscode.Uri[],
+		fileType: 'artifact' | 'contract',
+	): GrouppedFileItem[] => {
+		const patterns = fileType === 'artifact'
+			? GrouppedFileItem.artifactChildrenSpecifiers
+			: GrouppedFileItem.contractChildrenSpecifiers;
+		const filesAndPatterns = files.map(f => new GrouppedFileItem(f, folder, patterns));
+		const rootFiles = filesAndPatterns.filter(f => !f.isChild);
+		const children = filesAndPatterns.filter(f => f.isChild);
+		children.forEach(child => {
+			const rootFile = rootFiles.find(root => root.relativePath === child.expectedParentName);
+			if (rootFile) {
+				rootFile.children.push(child);
+			} else {
+				rootFiles.push(child);
+			}
+		});
+		rootFiles.sort();
+		rootFiles.forEach(f => f.children.sort());
+		return rootFiles;
+	};
+
+	private static getFirstMatch(fileName: string, patterns: RegExp[]): RegExpExecArray | undefined {
+		for (const pattern of patterns) {
+			const result = pattern.exec(fileName);
+			if (result) {
+				return result;
+			}
+		}
+		return undefined;
+	}
+}

--- a/taqueria-vscode-extension/src/lib/helpers.ts
+++ b/taqueria-vscode-extension/src/lib/helpers.ts
@@ -268,6 +268,20 @@ export class VsCodeHelper {
 		return this.i18;
 	}
 
+	private _imagesPath: string | undefined = undefined;
+	async getImagesPath(): Promise<string> {
+		if (this._imagesPath) {
+			return this._imagesPath;
+		}
+		try {
+			await Util.makeDir(path.join(__filename, '..', '..', 'images'), this.i18);
+			this._imagesPath = path.join(__filename, '..', '..', 'images');
+		} catch {
+			this._imagesPath = path.join(__filename, '..', '..', '..', '..', 'images');
+		}
+		return this._imagesPath;
+	}
+
 	async getAnalytics() {
 		if (!this.analytics) {
 			const taqVersion = (await this.getTaqVersion()) || 'unknown';


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

We have conventions for files that are storage, argument or expression for a main contract file. Like `contractName.default_storage.tz`. The contracts and artifacts treeviews were flat. It is nice to show these files as children nodes to the main contracts.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

The Contracts and Artifacts TreeViews now recognize the patterns that relate contracts to their storage, argument and expression files, and show them as subtrees.

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [ ] 🛠️ Fix ➾
- [x] ✨ Feature ➾ Show Storage, Argument, and Expression Files as Children of the Main Contract in TreeViews.
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
