### PR TITLE
🛠️ Fix ➾ Closes #1824, transfer task not finding aliases

### DIFF
--- a/taqueria-protocol/types-config-files.ts
+++ b/taqueria-protocol/types-config-files.ts
@@ -293,6 +293,7 @@ export const transformConfigToConfigFileV2 = (config: Config): ConfigFileSetV2 =
 
 // FileV2 to Object
 export const transformConfigFileV2ToConfig = (configFileSetV2: ConfigFileSetV2): Config => {
+	debugger;
 	const {
 		config: configFileV2,
 		environments: environmentFilesV2,
@@ -389,11 +390,27 @@ export const transformConfigFileV2ToConfig = (configFileSetV2: ConfigFileSetV2):
 				rpcUrl: x.value.rpcUrl ?? ``,
 				// Unknown fields might need to be in the network or sandbox
 				...getUnknownFields(x, 'network') as {},
-				...(() => {
-					return {
-						accounts: x.value.accounts,
-					};
-				})(),
+				...['accounts', 'contracts'].reduce(
+					(retval, fieldName) => {
+						if (fieldName === 'accounts') {
+							return x.value.accounts
+								? {
+									...retval,
+									accounts: x.value.accounts,
+								}
+								: retval;
+						} else if (fieldName === 'contracts') {
+							return x.value.aliases
+								? {
+									...retval,
+									contracts: x.value.aliases,
+								}
+								: retval;
+						}
+						return retval;
+					},
+					{},
+				),
 			}])) as Record<string, NetworkConfig>,
 		sandbox: !sandboxEnvironments.length
 			? undefined

--- a/taqueria-protocol/types-config-files.ts
+++ b/taqueria-protocol/types-config-files.ts
@@ -293,7 +293,6 @@ export const transformConfigToConfigFileV2 = (config: Config): ConfigFileSetV2 =
 
 // FileV2 to Object
 export const transformConfigFileV2ToConfig = (configFileSetV2: ConfigFileSetV2): Config => {
-	debugger;
 	const {
 		config: configFileV2,
 		environments: environmentFilesV2,


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

The `taq transfer` task was not finding aliases in the Config runtime object due to a mis-transformation from V2 config.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] 🔱 The test plan has been implemented and verified by an SDET
- [x] 🦀 Automated tests have been written and added to this PR
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [x] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [x] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Added `aliases` to network config of the runtime Config object.

## 🎢 Test Plan

Re-run the steps in the issue.