### PR TITLE
Ability to install plugins with specific version in TVsCE

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,8 @@
 			"outFiles": ["${workspaceFolder}/taqueria-vscode-extension/out/**/*.js"],
 			"preLaunchTask": "build-and-watch-vscode",
 			"env": {
-				"LogLevel": "warn",
-				"InstallDevPlugins": "false"
+				"TaqLogLevel": "warn",
+				"PluginVersionToInstall": "local"
 			}
 		},
 		{
@@ -30,7 +30,7 @@
 			"outFiles": ["${workspaceFolder}/taqueria-vscode-extension/out/**/*.js"],
 			"preLaunchTask": "npm: pretest",
 			"env": {
-				"LogLevel": "debug"
+				"TaqLogLevel": "warn"
 			}
 		}
 	]

--- a/taqueria-vscode-extension/src/lib/LogHelper.ts
+++ b/taqueria-vscode-extension/src/lib/LogHelper.ts
@@ -45,7 +45,7 @@ export class LogHelper {
 	}
 
 	constructor(vscode: VsCodeApi) {
-		const logLevelText = process.env.LogLevel ?? OutputLevels[OutputLevels.warn];
+		const logLevelText = process.env.TaqLogLevel ?? OutputLevels[OutputLevels.warn];
 		this._logLevel = OutputLevels[logLevelText as keyof typeof OutputLevels] ?? OutputLevels.warn;
 		this._outputChannel = vscode.window.createOutputChannel('Taqueria');
 		this._logChannel = vscode.window.createOutputChannel('Taqueria Logs');

--- a/taqueria-vscode-extension/src/lib/helpers.ts
+++ b/taqueria-vscode-extension/src/lib/helpers.ts
@@ -529,14 +529,17 @@ export class VsCodeHelper {
 	}
 
 	async getPathForPluginSource(pluginName: string) {
-		if (pluginName && process.env.InstallDevPlugins === 'true') {
+		if (!pluginName || !process.env.PluginVersionToInstall) {
+			return pluginName;
+		}
+		if (process.env.PluginVersionToInstall === 'local') {
 			const pathToTaq = await this.getTaqBinPath();
 			const taqFolder = path.dirname(pathToTaq);
 			const pluginFolder = pluginName.replace('@', '').replace('/', '-');
 			const pluginPath = path.join(taqFolder, pluginFolder);
 			return pluginPath;
 		}
-		return pluginName;
+		return `${pluginName}@${process.env.PluginVersionToInstall}`;
 	}
 
 	async promptForPluginInstallation(


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

In TVsCE it is useful to be able to specify which version of plugins should be installed. Previously we only had the option to install the release ones or the locally built ones.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [x] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

The environment variable `PluginVersionToInstall` can be left empty, which installs the release plugins, or `next` which installs the prerelease plugins.

If set to `local`, it will install plugins from the locally built repository. This expects that the `taq` binary is found from that repository.

## 🎢 Test Plan

_Please describe the testing strategy and plan for this PR. Keep this lightweight and anticipate any testing challenges_

## 🛸 Type of Change

- [ ] 🧽 Chore ➾
- [ ] 🛠️ Fix ➾
- [x] ✨ Feature ➾ Ability to install plugins with specific version in TVsCE
- [ ] 👷 Refactor ➾
- [ ] 🧪 Pre-Release ➾
- [ ] 🚀 Release ➾
