### PR TITLE
🛠️ Fix ➾ Closes #1711, update tests to assert that contextual help is working

### DIFF
--- a/tests/e2e/contract-types-plugin-e2e-tests.spec.ts
+++ b/tests/e2e/contract-types-plugin-e2e-tests.spec.ts
@@ -19,17 +19,14 @@ describe('Contract Types Plugin E2E Testing for Taqueria CLI', () => {
 		await cleanup();
 	});
 
-	// see https://github.com/ecadlabs/taqueria/issues/1635
-	// this works in manual test of pre-release v0.25.23-rc
-	// perhaps the automated tests have problem with the space in the task name
-	test.skip('generate types offers contextual help', async () => {
+	test('generate types offers contextual help', async () => {
 		const { execute, spawn, cleanup } = await prepareEnvironment();
 		const { waitForText } = await spawn('taq', 'init test-project');
 		await waitForText("Project taq'ified!");
 		const { stdout } = await execute('taq', 'install ../taqueria-plugin-contract-types', './test-project');
 		expect(stdout).toContain('Plugin installed successfully');
 
-		const { stdout: stdout2, stderr } = await execute('taq', 'generate types --help');
+		const { stdout: stdout2, stderr } = await execute('taq', 'generate types --help', './test-project');
 		console.log(stderr);
 		console.log(stdout2);
 		expect(stdout2).toEqual(expect.arrayContaining(['Generate types for a contract to be used with taquito']));

--- a/tests/e2e/taquito-plugin-e2e-tests.spec.ts
+++ b/tests/e2e/taquito-plugin-e2e-tests.spec.ts
@@ -98,10 +98,7 @@ describe('Taquito Plugin E2E testing for Taqueria CLI', () => {
 		await cleanup();
 	});
 
-	// see https://github.com/ecadlabs/taqueria/issues/1635
-	// works manually
-	// might not be working in tests because of the hyphen in the task name
-	test.skip('instantiate-account will give contextual help', async () => {
+	test('instantiate-account will give contextual help', async () => {
 		const { execute, spawn, cleanup } = await prepareEnvironment();
 		const { waitForText } = await spawn('taq', 'init test-project');
 		await waitForText("Project taq'ified!");
@@ -112,9 +109,9 @@ describe('Taquito Plugin E2E testing for Taqueria CLI', () => {
 		);
 		expect(stdout1).toEqual(expect.arrayContaining(['Plugin installed successfully']));
 
-		const { stdout: stdout2 } = await execute('taq', 'instantiate-account --help');
-		expect(stdout2).toContain(
-			'Instantiate all accounts declared in the "accounts" field at the root level of the config file to a target environment',
+		const { stdout: stdout2 } = await execute('taq', 'instantiate-account --help', './test-project');
+		expect(stdout2.join('')).toContain(
+			'Instantiate all accounts declared in the "accounts" field at the root level',
 		);
 
 		await cleanup();


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Issue #1711 was created to fix contextual help with various tasks:

#### contract-types plugin
- generate

#### taquito-plugin
- transfer
- call
- fund
- instantiate-account

The contextual help was actually for these tasks, but the tests needed some adjustment.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [x] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [x] 🏖️ New and existing unit tests pass locally and in CI
- [x] 🦀 Automated tests have been written and added to this PR
- [x] 🐬 I have commented my code, particularly in hard-to-understand areas
- [x] 🤿 Corresponding changes have been made to all documentation
- [x] 🐚 Required changes to the VScE have been made
- [x] 🪸 Required updates to scaffolds have been made
- [x] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Adjusted tests:
- The test used to assert that contextual help was working for the `generate` task was missing a `cwd` option.
- The tests in the taquito e2e suite was producing a false-negative as it was looking for a string that was split between two lines.

## 🎢 Test Plan

Re-run existing tests.