### PR TITLE
🛠️ Fix ➾ Don't require sandbox name for any task

### DIFF
--- a/taqueria-plugin-flextesa/index.ts
+++ b/taqueria-plugin-flextesa/index.ts
@@ -8,51 +8,33 @@ Plugin.create(_i18n => ({
 	tasks: [
 		Task.create({
 			task: 'start sandbox',
-			command: 'start sandbox [sandboxName]',
+			command: 'start sandbox',
 			aliases: ['start flextesa'],
 			description: 'Starts a flextesa sandbox',
 			options: [],
 			handler: 'proxy',
-			positionals: [
-				PositionalArg.create({
-					placeholder: 'sandboxName',
-					description: 'The name of the sandbox to start',
-				}),
-			],
 			encoding: 'none',
 		}),
 		Task.create({
 			task: 'stop sandbox',
-			command: 'stop sandbox [sandboxName]',
+			command: 'stop sandbox',
 			aliases: ['stop flextesa'],
 			description: 'Stops a flextesa sandbox',
 			options: [],
 			handler: 'proxy',
-			positionals: [
-				PositionalArg.create({
-					placeholder: 'sandboxName',
-					description: 'The name of the sandbox to stop',
-				}),
-			],
 		}),
 		Task.create({
 			task: 'list accounts',
-			command: 'list accounts <sandboxName>',
+			command: 'list accounts',
 			aliases: [],
 			description: 'List the balances of all sandbox accounts',
 			options: [],
 			handler: 'proxy',
-			positionals: [
-				PositionalArg.create({
-					placeholder: 'sandboxName',
-					description: 'The name of the sandbox to use',
-				}),
-			],
 			encoding: 'json',
 		}),
 		Task.create({
 			task: 'bake',
-			command: 'bake <sandboxName>',
+			command: 'bake',
 			aliases: ['b'],
 			description: 'Manually bake a block. Use when the "baking" setting of a flextesa sandbox is set to "disabled".',
 			options: [
@@ -66,12 +48,6 @@ Plugin.create(_i18n => ({
 			],
 			handler: 'proxy',
 			encoding: 'none',
-			positionals: [
-				PositionalArg.create({
-					placeholder: 'sandboxName',
-					description: 'The name of the sandbox to stop',
-				}),
-			],
 		}),
 		Task.create({
 			task: 'show protocols',

--- a/tests/e2e/flextesa-plugin-e2e-tests.spec.ts
+++ b/tests/e2e/flextesa-plugin-e2e-tests.spec.ts
@@ -4,29 +4,6 @@ const exec = util.promisify(exec1);
 import { prepareEnvironment } from '@gmrchk/cli-testing-library';
 
 describe('Flextesa Plugin E2E Testing for Taqueria CLI', () => {
-	test('start and stop will work with a custom name sandbox - slowtest', async () => {
-		const { execute, cleanup, writeFile, exists } = await prepareEnvironment();
-		await execute('taq', 'init test-project');
-		await exists('./test-project/.taq/config.json');
-		const config_file = await (await exec('cat e2e/data/config-data/config-flextesa-test-sandbox.json')).stdout;
-		await writeFile('./test-project/.taq/config.json', config_file);
-
-		await execute('taq', 'install ../taqueria-plugin-flextesa', './test-project');
-		await exists('./test-project/node_modules/@taqueria/plugin-flextesa/index.js');
-
-		const { stdout: stdout2 } = await execute('taq', 'start sandbox test', './test-project');
-		expect(stdout2).toEqual(expect.arrayContaining(['Starting node...']));
-
-		const { stdout: stdout3 } = await execute('docker', 'ps --filter name=taq-flextesa-test', './test-project');
-		expect(stdout3).toEqual(expect.arrayContaining([expect.stringContaining('taq-flextesa-test')]));
-		expect(stdout3).toEqual(expect.arrayContaining([expect.stringContaining('oxhead')]));
-
-		const { stdout: stdout4 } = await execute('taq', 'stop sandbox test', './test-project');
-		await expect(stdout4).toEqual(expect.arrayContaining(['Stopped test.']));
-
-		await cleanup();
-	});
-
 	test('start sandbox will offer contextual help', async () => {
 		const { execute, cleanup, exists } = await prepareEnvironment();
 		await execute('taq', 'init test-project');

--- a/tests/e2e/flextesa-plugin-e2e-tests.spec.ts
+++ b/tests/e2e/flextesa-plugin-e2e-tests.spec.ts
@@ -63,20 +63,6 @@ describe('Flextesa Plugin E2E Testing for Taqueria CLI', () => {
 		await cleanup();
 	});
 
-	test('start sandbox will error if incorrect sandbox name called', async () => {
-		const { execute, cleanup, exists } = await prepareEnvironment();
-		await execute('taq', 'init test-project');
-		await exists('./test-project/.taq/config.json');
-
-		await execute('taq', 'install ../taqueria-plugin-flextesa', './test-project');
-		await exists('./test-project/node_modules/@taqueria/plugin-flextesa/index.js');
-
-		const { stderr } = await execute('taq', 'start sandbox no_such_sandbox', './test-project');
-		expect(stderr).toEqual(['There is no sandbox called no_such_sandbox in your .taq/config.json.']);
-
-		await cleanup();
-	});
-
 	test('show protocols will offer known protocols', async () => {
 		const { execute, cleanup, exists } = await prepareEnvironment();
 		await execute('taq', 'init test-project');


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

With the new environment refactor, an environment can only ever have one sandbox associated with it, and thus, we don't need to specify a sandbox name for any task provided by the flextesa plugin.