### PR TITLE
🛠️ Fix ➾ Add restart sandbox task, and ensure that all taquito tasks will retry until max timeout elapsed

### DIFF
--- a/taqueria-plugin-flextesa/index.ts
+++ b/taqueria-plugin-flextesa/index.ts
@@ -24,6 +24,14 @@ Plugin.create(_i18n => ({
 			handler: 'proxy',
 		}),
 		Task.create({
+			task: 'restart sandbox',
+			command: 'restart sandbox',
+			aliases: ['restart flextesa'],
+			description: 'Restarts a flextesa sandbox',
+			options: [],
+			handler: 'proxy',
+		}),
+		Task.create({
 			task: 'list accounts',
 			command: 'list accounts',
 			aliases: [],

--- a/taqueria-plugin-flextesa/proxy.ts
+++ b/taqueria-plugin-flextesa/proxy.ts
@@ -441,6 +441,11 @@ const stopSandboxTask = async (parsedArgs: ValidOpts): Promise<void> => {
 	return sendAsyncErr(`No sandbox specified`);
 };
 
+const restartSandboxTask = async (parsedArgs: ValidOpts): Promise<void> => {
+	await stopSandboxTask(parsedArgs);
+	await startSandboxTask(parsedArgs);
+};
+
 const stopTzKtContainers = async (
 	sandboxName: string,
 	sandbox: SandboxConfig.t,
@@ -577,6 +582,8 @@ const taskMap: Record<string, (opts: ValidOpts) => Promise<void>> = {
 	'stop flextesa': stopSandboxTask,
 	'bake': bakeTask,
 	'b': bakeTask,
+	'restart sandbox': restartSandboxTask,
+	'restart flextesa': restartSandboxTask,
 };
 
 const validateRequest = async (unparsedArgs: Opts) => {

--- a/taqueria-plugin-taquito/fund.ts
+++ b/taqueria-plugin-taquito/fund.ts
@@ -9,6 +9,7 @@ import {
 import { TezosToolkit } from '@taquito/taquito';
 import {
 	configureToolKitForNetwork,
+	FundOpts,
 	FundOpts as Opts,
 	getDeclaredAccounts,
 	getEnvTypeAndNodeConfig,
@@ -64,7 +65,7 @@ const prepAccountsInfoForDisplay = (accountsInfo: ContractInfo[]): TableRow[] =>
 		};
 	});
 
-const fund = async (parsedArgs: RequestArgs.t): Promise<void> => {
+const fund = async (parsedArgs: FundOpts): Promise<void> => {
 	const env = getCurrentEnvironmentConfig(parsedArgs);
 	if (!env) return sendAsyncErr(`There is no environment called ${parsedArgs.env} in your config.json`);
 	try {
@@ -81,7 +82,7 @@ const fund = async (parsedArgs: RequestArgs.t): Promise<void> => {
 			);
 		}
 
-		await performTransferOps(tezos, getCurrentEnvironment(parsedArgs), accountsInfo);
+		await performTransferOps(tezos, getCurrentEnvironment(parsedArgs), accountsInfo, parsedArgs.timeout);
 
 		const accountsInfoForDisplay = prepAccountsInfoForDisplay(accountsInfo);
 		return sendJsonRes(accountsInfoForDisplay);

--- a/taqueria-plugin-taquito/index.ts
+++ b/taqueria-plugin-taquito/index.ts
@@ -35,7 +35,7 @@ Plugin.create(_i18n => ({
 				Option.create({
 					flag: 'timeout',
 					shortFlag: 't',
-					defaultValue: 30,
+					defaultValue: 40,
 					description: 'Number of retry attempts (to avoid congestion and network failures)',
 					required: false,
 				}),
@@ -72,6 +72,13 @@ Plugin.create(_i18n => ({
 					description: 'Name of an instantiated account to use as the sender of the transfer operation',
 					required: false,
 				}),
+				Option.create({
+					flag: 'timeout',
+					shortFlag: 't',
+					defaultValue: 40,
+					description: 'Number of retry attempts (to avoid congestion and network failures)',
+					required: false,
+				}),
 			],
 			aliases: ['call'],
 			handler: 'proxy',
@@ -83,6 +90,15 @@ Plugin.create(_i18n => ({
 			description: 'Fund all the instantiated accounts up to the desired/declared amount in a target environment',
 			handler: 'proxy',
 			encoding: 'application/json',
+			options: [
+				Option.create({
+					flag: 'timeout',
+					shortFlag: 't',
+					defaultValue: 40,
+					description: 'Number of retry attempts (to avoid congestion and network failures)',
+					required: false,
+				}),
+			],
 		}),
 		Task.create({
 			task: 'instantiate-account',

--- a/taqueria-plugin-taquito/index.ts
+++ b/taqueria-plugin-taquito/index.ts
@@ -32,6 +32,13 @@ Plugin.create(_i18n => ({
 					description: 'Amount of Mutez to transfer',
 					required: false,
 				}),
+				Option.create({
+					flag: 'timeout',
+					shortFlag: 't',
+					defaultValue: 30,
+					description: 'Number of retry attempts (to avoid congestion and network failures)',
+					required: false,
+				}),
 			],
 			aliases: ['originate'],
 			handler: 'proxy',

--- a/taqueria-plugin-taquito/main.ts
+++ b/taqueria-plugin-taquito/main.ts
@@ -15,7 +15,7 @@ export const main = (parsedArgs: RequestArgs.t): Promise<void> => {
 		case 'instantiate-account':
 			return instantiate_account(parsedArgs);
 		case 'fund':
-			return fund(parsedArgs);
+			return fund(unsafeArgs);
 		default:
 			return sendAsyncErr(`${unsafeArgs} is not an understood task by the Taquito plugin`);
 	}

--- a/taqueria-plugin-taquito/tsconfig.json
+++ b/taqueria-plugin-taquito/tsconfig.json
@@ -13,7 +13,8 @@
 		/* Language and Environment */
 		"target": "ES2021", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
 		"lib": [
-			"ES2021.String"
+			"ES2021.String",
+			"ES2021.Promise"
 		], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
 		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

- Added a new task to the flextesa plugin called `restart sandbox`. 
- Adjusted all tasks of the taquito plugin to accept a `timeout` option, with a default value of 40 seconds.
- All taquito tasks (originate, fund, and transfer) will continuously retry upon failure up to the timeout value above). Closes #1846 