### PR TITLE
🚀 Release ➾ v0.28.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "node_modules/lerna/schemas/lerna-schema.json",
 	"useWorkspaces": true,
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"useNx": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@taqueria/taqueria",
-	"version": "0.29.0",
+	"version": "0.28.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@taqueria/taqueria",
-			"version": "0.29.0",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"workspaces": [
 				"./taqueria-protocol",
@@ -27356,10 +27356,10 @@
 		},
 		"taqueria-analytics": {
 			"name": "@taqueria/analytics",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/protocol": "^0.28.3",
 				"node-machine-id-xz": "^1.0.2"
 			},
 			"devDependencies": {
@@ -27369,10 +27369,10 @@
 		},
 		"taqueria-plugin-archetype": {
 			"name": "@taqueria/plugin-archetype",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"fast-glob": "^3.2.11",
 				"ts-pattern": "^3.3.3"
 			},
@@ -27383,10 +27383,10 @@
 		},
 		"taqueria-plugin-contract-types": {
 			"name": "@taqueria/plugin-contract-types",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "ISC",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"@taquito/michel-codec": "^15.0.0",
 				"@taquito/signer": "^15.0.0",
 				"@taquito/taquito": "^15.0.0",
@@ -27411,10 +27411,10 @@
 		},
 		"taqueria-plugin-core": {
 			"name": "@taqueria/plugin-core",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2"
+				"@taqueria/node-sdk": "^0.28.3"
 			},
 			"devDependencies": {
 				"tsup": "^6.5.0",
@@ -27426,11 +27426,11 @@
 		},
 		"taqueria-plugin-flextesa": {
 			"name": "@taqueria/plugin-flextesa",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
+				"@taqueria/protocol": "^0.28.3",
 				"async-retry": "^1.3.3",
 				"fast-glob": "^3.2.11",
 				"portfinder": "^1.0.28",
@@ -27444,10 +27444,10 @@
 		},
 		"taqueria-plugin-ipfs-pinata": {
 			"name": "@taqueria/plugin-ipfs-pinata",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"dotenv": "^16.0.0",
 				"form-data": "^4.0.0",
 				"ipfs-only-hash": "^4.0.0",
@@ -27473,11 +27473,11 @@
 		},
 		"taqueria-plugin-jest": {
 			"name": "@taqueria/plugin-jest",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
-				"@taqueria/plugin-contract-types": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
+				"@taqueria/plugin-contract-types": "^0.28.3",
 				"@taquito/signer": "^15.0.0",
 				"@taquito/taquito": "^15.0.0",
 				"@taquito/utils": "^15.0.0",
@@ -27509,10 +27509,10 @@
 		},
 		"taqueria-plugin-ligo": {
 			"name": "@taqueria/plugin-ligo",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"fast-glob": "^3.2.11"
 			},
 			"devDependencies": {
@@ -27522,11 +27522,11 @@
 		},
 		"taqueria-plugin-metadata": {
 			"name": "@taqueria/plugin-metadata",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
+				"@taqueria/protocol": "^0.28.3",
 				"prompts": "^2.4.2"
 			},
 			"devDependencies": {
@@ -27592,10 +27592,10 @@
 		},
 		"taqueria-plugin-smartpy": {
 			"name": "@taqueria/plugin-smartpy",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"fast-glob": "^3.2.11"
 			},
 			"devDependencies": {
@@ -27608,10 +27608,10 @@
 		},
 		"taqueria-plugin-taquito": {
 			"name": "@taqueria/plugin-taquito",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"@taquito/michel-codec": "^15.0.0",
 				"@taquito/signer": "^15.0.0",
 				"@taquito/taquito": "^15.0.0",
@@ -27627,10 +27627,10 @@
 		},
 		"taqueria-plugin-tezos-client": {
 			"name": "@taqueria/plugin-tezos-client",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"fast-glob": "^3.2.7"
 			},
 			"devDependencies": {
@@ -27643,7 +27643,7 @@
 		},
 		"taqueria-protocol": {
 			"name": "@taqueria/protocol",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@peculiar/webcrypto": "^1.4.0",
@@ -27663,10 +27663,10 @@
 		},
 		"taqueria-sdk": {
 			"name": "@taqueria/node-sdk",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/protocol": "^0.28.3",
 				"@taquito/signer": "^15.0.0",
 				"@taquito/taquito": "^15.0.0",
 				"@taquito/utils": "^15.0.0",
@@ -27699,10 +27699,10 @@
 		},
 		"taqueria-toolkit": {
 			"name": "@taqueria/toolkit",
-			"version": "0.28.2",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/protocol": "^0.28.3",
 				"cross-spawn": "^7.0.3",
 				"yargs": "^17.6.2"
 			},
@@ -27724,7 +27724,7 @@
 		},
 		"taqueria-vscode-extension": {
 			"name": "taqueria-vscode",
-			"version": "0.29.0",
+			"version": "0.28.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@microsoft/signalr": "^6.0.8",
@@ -32903,7 +32903,7 @@
 		"@taqueria/analytics": {
 			"version": "file:taqueria-analytics",
 			"requires": {
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/protocol": "^0.28.3",
 				"node-machine-id-xz": "^1.0.2",
 				"tsup": "^6.5.0",
 				"typescript": "^4.7.2"
@@ -32913,7 +32913,7 @@
 			"version": "file:taqueria-sdk",
 			"requires": {
 				"@bevry/jsonfile": "^1.3.0",
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/protocol": "^0.28.3",
 				"@taquito/signer": "^15.0.0",
 				"@taquito/taquito": "^15.0.0",
 				"@taquito/utils": "^15.0.0",
@@ -32944,7 +32944,7 @@
 		"@taqueria/plugin-archetype": {
 			"version": "file:taqueria-plugin-archetype",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"fast-glob": "^3.2.11",
 				"ts-pattern": "^3.3.3",
 				"tsup": "^6.5.0",
@@ -32954,7 +32954,7 @@
 		"@taqueria/plugin-contract-types": {
 			"version": "file:taqueria-plugin-contract-types",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"@taquito/michel-codec": "^15.0.0",
 				"@taquito/signer": "^15.0.0",
 				"@taquito/taquito": "^15.0.0",
@@ -32979,7 +32979,7 @@
 		"@taqueria/plugin-core": {
 			"version": "file:taqueria-plugin-core",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"tsup": "^6.5.0",
 				"typescript": "^4.7.2"
 			}
@@ -32987,8 +32987,8 @@
 		"@taqueria/plugin-flextesa": {
 			"version": "file:taqueria-plugin-flextesa",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
+				"@taqueria/protocol": "^0.28.3",
 				"@types/async-retry": "^1.4.4",
 				"async-retry": "^1.3.3",
 				"fast-glob": "^3.2.11",
@@ -33001,7 +33001,7 @@
 		"@taqueria/plugin-ipfs-pinata": {
 			"version": "file:taqueria-plugin-ipfs-pinata",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"@types/node-fetch": "^2.6.1",
 				"dotenv": "^16.0.0",
 				"form-data": "^4.0.0",
@@ -33020,8 +33020,8 @@
 		"@taqueria/plugin-jest": {
 			"version": "file:taqueria-plugin-jest",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
-				"@taqueria/plugin-contract-types": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
+				"@taqueria/plugin-contract-types": "^0.28.3",
 				"@taquito/signer": "^15.0.0",
 				"@taquito/taquito": "^15.0.0",
 				"@taquito/utils": "^15.0.0",
@@ -33046,7 +33046,7 @@
 		"@taqueria/plugin-ligo": {
 			"version": "file:taqueria-plugin-ligo",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"fast-glob": "^3.2.11",
 				"tsup": "^6.5.0",
 				"typescript": "^4.7.2"
@@ -33055,8 +33055,8 @@
 		"@taqueria/plugin-metadata": {
 			"version": "file:taqueria-plugin-metadata",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
+				"@taqueria/protocol": "^0.28.3",
 				"@types/prompts": "^2.0.14",
 				"prompts": "^2.4.2",
 				"tsup": "^6.5.0",
@@ -33112,7 +33112,7 @@
 		"@taqueria/plugin-smartpy": {
 			"version": "file:taqueria-plugin-smartpy",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"fast-glob": "^3.2.11",
 				"tsup": "^6.5.0",
 				"typescript": "^4.7.2"
@@ -33121,7 +33121,7 @@
 		"@taqueria/plugin-taquito": {
 			"version": "file:taqueria-plugin-taquito",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"@taquito/michel-codec": "^15.0.0",
 				"@taquito/signer": "^15.0.0",
 				"@taquito/taquito": "^15.0.0",
@@ -33133,7 +33133,7 @@
 		"@taqueria/plugin-tezos-client": {
 			"version": "file:taqueria-plugin-tezos-client",
 			"requires": {
-				"@taqueria/node-sdk": "^0.28.2",
+				"@taqueria/node-sdk": "^0.28.3",
 				"fast-glob": "^3.2.7",
 				"tsup": "^6.5.0",
 				"typescript": "^4.7.2"
@@ -33895,7 +33895,7 @@
 		"@taqueria/toolkit": {
 			"version": "file:taqueria-toolkit",
 			"requires": {
-				"@taqueria/protocol": "^0.28.2",
+				"@taqueria/protocol": "^0.28.3",
 				"@types/cross-spawn": "^6.0.2",
 				"@types/node": "^17.0.12",
 				"@types/yargs": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/taqueria",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "An easy to use opinionated tool for building, testing, and deploying Tezos software",
 	"main": "index.ts",
 	"directories": {

--- a/taqueria-analytics/package.json
+++ b/taqueria-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/analytics",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A TypeScript SDK submitting events for Taqueria activity",
 	"main": "./index.js",
 	"source": "./index.ts",
@@ -34,7 +34,7 @@
 	},
 	"homepage": "https://github.com/ecadlabs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/protocol": "^0.28.2",
+		"@taqueria/protocol": "^0.28.3",
 		"node-machine-id-xz": "^1.0.2"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-archetype/package.json
+++ b/taqueria-plugin-archetype/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-archetype",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A taqueria plugin for compiling Archetype smart contracts",
 	"targets": {
 		"default": {
@@ -40,7 +40,7 @@
 	},
 	"homepage": "https://github.com/ecadlabs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
 		"fast-glob": "^3.2.11",
 		"ts-pattern": "^3.3.3"
 	},

--- a/taqueria-plugin-contract-types/package.json
+++ b/taqueria-plugin-contract-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-contract-types",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"main": "index.cjs",
 	"module": "index.js",
 	"source": "index.ts",
@@ -34,7 +34,7 @@
 		"typescript": "^4.7.2"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
 		"@taquito/michel-codec": "^15.0.0",
 		"@taquito/signer": "^15.0.0",
 		"@taquito/taquito": "^15.0.0",

--- a/taqueria-plugin-core/package.json
+++ b/taqueria-plugin-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-core",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A taqueria plugin for core tasks",
 	"targets": {
 		"default": {
@@ -43,7 +43,7 @@
 		"typescript": "^4.7.2"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2"
+		"@taqueria/node-sdk": "^0.28.3"
 	},
 	"tsup": {
 		"entry": [

--- a/taqueria-plugin-flextesa/package.json
+++ b/taqueria-plugin-flextesa/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-flextesa",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A plugin for Taqueria providing local sandbox capabilities built on Flextesa",
 	"keywords": [
 		"taqueria",
@@ -34,8 +34,8 @@
 		"directory": "taqueria-plugin-flextesa"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
-		"@taqueria/protocol": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
+		"@taqueria/protocol": "^0.28.3",
 		"async-retry": "^1.3.3",
 		"fast-glob": "^3.2.11",
 		"portfinder": "^1.0.28",

--- a/taqueria-plugin-ipfs-pinata/package.json
+++ b/taqueria-plugin-ipfs-pinata/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-ipfs-pinata",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A plugin for Taqueria providing ipfs publishing and pinning using the Pinata service",
 	"keywords": [
 		"taqueria",
@@ -33,7 +33,7 @@
 		"directory": "taqueria-plugin-ipfs-pinata"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
 		"dotenv": "^16.0.0",
 		"form-data": "^4.0.0",
 		"ipfs-only-hash": "^4.0.0",

--- a/taqueria-plugin-jest/package.json
+++ b/taqueria-plugin-jest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-jest",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"main": "index.cjs",
 	"module": "index.js",
 	"source": "index.ts",
@@ -27,8 +27,8 @@
 		"directory": "taqueria-plugin-jest"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
-		"@taqueria/plugin-contract-types": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
+		"@taqueria/plugin-contract-types": "^0.28.3",
 		"@taquito/signer": "^15.0.0",
 		"@taquito/taquito": "^15.0.0",
 		"@taquito/utils": "^15.0.0",

--- a/taqueria-plugin-ligo/package.json
+++ b/taqueria-plugin-ligo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-ligo",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A taqueria plugin for compiling LIGO smart contracts",
 	"targets": {
 		"default": {
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/ecadlabs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
 		"fast-glob": "^3.2.11"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-metadata/package.json
+++ b/taqueria-plugin-metadata/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-metadata",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A plugin for Taqueria providing metadata creation and validation.",
 	"keywords": [
 		"taqueria",
@@ -31,8 +31,8 @@
 		"directory": "taqueria-plugin-metadata"
 	},
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
-		"@taqueria/protocol": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
+		"@taqueria/protocol": "^0.28.3",
 		"prompts": "^2.4.2"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-smartpy/package.json
+++ b/taqueria-plugin-smartpy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-smartpy",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A taqueria plugin for compiling SmartPy smart contracts",
 	"targets": {
 		"default": {
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/ecadlabs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
 		"fast-glob": "^3.2.11"
 	},
 	"devDependencies": {

--- a/taqueria-plugin-taquito/package.json
+++ b/taqueria-plugin-taquito/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-taquito",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A taqueria plugin for originating smart contracts using Taquito",
 	"targets": {
 		"default": {
@@ -42,7 +42,7 @@
 	},
 	"homepage": "https://github.com/ecadlabs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
 		"@taquito/michel-codec": "^15.0.0",
 		"@taquito/signer": "^15.0.0",
 		"@taquito/taquito": "^15.0.0",

--- a/taqueria-plugin-tezos-client/package.json
+++ b/taqueria-plugin-tezos-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/plugin-tezos-client",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A taqueria plugin for utilizing tezos-client",
 	"targets": {
 		"default": {
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/ecadlabs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/node-sdk": "^0.28.2",
+		"@taqueria/node-sdk": "^0.28.3",
 		"fast-glob": "^3.2.7"
 	},
 	"devDependencies": {

--- a/taqueria-protocol/package.json
+++ b/taqueria-protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/protocol",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A TypeScript package which contains types that are to be shared between @taqueria/node-sdk and @taqueria/taqueria.",
 	"main": "index.js",
 	"scripts": {

--- a/taqueria-sdk/package.json
+++ b/taqueria-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/node-sdk",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A TypeScript SDK for NodeJS used for Taqueria plugin development.",
 	"main": "./index.js",
 	"source": "./index.ts",
@@ -34,7 +34,7 @@
 	},
 	"homepage": "https://github.com/ecadlabs/taqueria#readme",
 	"dependencies": {
-		"@taqueria/protocol": "^0.28.2",
+		"@taqueria/protocol": "^0.28.3",
 		"@taquito/signer": "^15.0.0",
 		"@taquito/taquito": "^15.0.0",
 		"@taquito/utils": "^15.0.0",

--- a/taqueria-toolkit/package.json
+++ b/taqueria-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taqueria/toolkit",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"description": "A TypeScript library for NodeJS to work with Taqueria projects",
 	"source": "./index.ts",
 	"main": "./index.js",
@@ -37,7 +37,7 @@
 		"typescript": "^4.7.2"
 	},
 	"dependencies": {
-		"@taqueria/protocol": "^0.28.2",
+		"@taqueria/protocol": "^0.28.3",
 		"cross-spawn": "^7.0.3",
 		"yargs": "^17.6.2"
 	},

--- a/taqueria-vscode-extension/package.json
+++ b/taqueria-vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Taqueria",
 	"description": "A better way to build on Tezos",
 	"publisher": "ecadlabs",
-	"version": "0.28.2",
+	"version": "0.28.3",
 	"private": true,
 	"engines": {
 		"vscode": "^1.68.1",

--- a/website/docs/release-notes.mdx
+++ b/website/docs/release-notes.mdx
@@ -11,24 +11,26 @@ title: Taqueria Releases
 
 ### Summary
 
-- Coming soon.
+#### Taquito plugin
+- The `transfer` and `deploy` tasks will now retry if an error occured trying to forge or inject an operation. The tasks will be retried until the max timeout is reached (set to 40 seconds by default).
+- Add a `--timeout` option to both the `transfer` and `deploy` tasks to adjust the max timeout before giving up on forging and injecting an operation.
+
+#### Flextesa plugin
+- Tasks provided by the flextesa plugin no longer require a sandbox name, which is now inferred from the environment. For example, to start a sandbox you would execute `taq start sandbox` instead of `taq start sandbox local`
+- Adds a `taq restart sandbox` task to stop and then restart an already-running sandbox. Useful when you adjust baking options.
+
+#### LIGO plugin
+- The `taq ligo` command can be used to create files, such as when you execute `taq ligo -c 'init contract --template multisig-jsligo'`. This release fixes a bug where these files would be owned by root.
+- Added missing tests to assure that parameter and storage files are handled properly.
+
 
 ### Pull Requests
 
-This is the most *comprehensive* list of changes since the last release, and provides detailed, per-change information.
-
-* 🛠️ Fix ➾ Closes #1711, update tests to assert that contextual help is working by @mweichert in #1830
-* 🧽 Chore ➾ Ability to install plugins with specific version in TVsCE by @AlirezaHaghshenas in #1827
-* 🧽 Chore ➾ Group Contracts and Artifacts in TreeViews by @AlirezaHaghshenas in #1825
-* 🛠️ Fix ➾ Contextual help test by @michaelkernaghan in #1833
-* 🛠️ Fix ➾ Add better error handling to withTaq binary by @mweichert in #1831
-* 🛠️ Fix ➾ Doc changes by @mweichert in #1837
-* 🧽 Chore ➾ Update flextesa docs by @mweichert in #1839
-* 🛠️ Fix ➾ Added docs for all missing docs except 'generate-project-metadata' and 'pin' by @mweichert in #1840
-* 🛠️ Fix ➾  Closes #1775, ensures that protocol package can be consumed by nodejs, deno, and browsers by @mweichert in #1836
-* 🛠️ Fix ➾ #1750, uninstall plugin emits error by @mweichert in #1821
-* 🛠️ Fix ➾ Dynamically set the column wrapping of the yargs help menu by @mweichert in #1842
-* 🧪 Pre-Release ➾ v0.28.1 (and VSCode v0.29.0) by @mweichert in #1841
+* 🛠️ Fix ➾ Don't require sandbox name for any task by @mweichert in https://github.com/ecadlabs/taqueria/pull/1844
+* 🛠️ Fix ➾ Ensure that files created by ligo/docker aren't owned by root by @mweichert in https://github.com/ecadlabs/taqueria/pull/1845
+* 🛠️ Fix ➾ Add restart sandbox task
+* 🛠️ Fix ➾ Ensure that all taquito tasks will retry until max timeout elapsed by @mweichert in https://github.com/ecadlabs/taqueria/pull/1847
+* 🧽 Chore ➾ add two tests for ligo compile file handling by @michaelkernaghan in https://github.com/ecadlabs/taqueria/pull/1817
 
 ** Full Changelog: https://github.com/ecadlabs/taqueria/compare/v0.28.2...0.28.3
 

--- a/website/docs/release-notes.mdx
+++ b/website/docs/release-notes.mdx
@@ -2,6 +2,67 @@
 title: Taqueria Releases
 ---
 
+## Taqueria v0.28.3
+| Details     |               |
+| ----------- | ------------- |
+|Release Date | Feb 16, 2023  |
+|Release Type | Minor         |
+|Release Page | [v0.28.2](https://github.com/ecadlabs/taqueria/releases/tag/v0.28.3) |
+
+### Summary
+
+- Coming soon.
+
+### Pull Requests
+
+This is the most *comprehensive* list of changes since the last release, and provides detailed, per-change information.
+
+* 🛠️ Fix ➾ Closes #1711, update tests to assert that contextual help is working by @mweichert in #1830
+* 🧽 Chore ➾ Ability to install plugins with specific version in TVsCE by @AlirezaHaghshenas in #1827
+* 🧽 Chore ➾ Group Contracts and Artifacts in TreeViews by @AlirezaHaghshenas in #1825
+* 🛠️ Fix ➾ Contextual help test by @michaelkernaghan in #1833
+* 🛠️ Fix ➾ Add better error handling to withTaq binary by @mweichert in #1831
+* 🛠️ Fix ➾ Doc changes by @mweichert in #1837
+* 🧽 Chore ➾ Update flextesa docs by @mweichert in #1839
+* 🛠️ Fix ➾ Added docs for all missing docs except 'generate-project-metadata' and 'pin' by @mweichert in #1840
+* 🛠️ Fix ➾  Closes #1775, ensures that protocol package can be consumed by nodejs, deno, and browsers by @mweichert in #1836
+* 🛠️ Fix ➾ #1750, uninstall plugin emits error by @mweichert in #1821
+* 🛠️ Fix ➾ Dynamically set the column wrapping of the yargs help menu by @mweichert in #1842
+* 🧪 Pre-Release ➾ v0.28.1 (and VSCode v0.29.0) by @mweichert in #1841
+
+** Full Changelog: https://github.com/ecadlabs/taqueria/compare/v0.28.2...0.28.3
+
+## Taqueria v0.28.2
+| Details     |               |
+| ----------- | ------------- |
+|Release Date | Feb 16, 2023  |
+|Release Type | Minor         |
+|Release Page | [v0.28.2](https://github.com/ecadlabs/taqueria/releases/tag/v0.28.2) |
+
+### Summary
+
+- CLI column width is dynamic. Help output will not be wrapped if your terminal width can accommodate longer lines of text.
+
+### Pull Requests
+
+This is the most *comprehensive* list of changes since the last release, and provides detailed, per-change information.
+
+* 🛠️ Fix ➾ Closes #1711, update tests to assert that contextual help is working by @mweichert in #1830
+* 🧽 Chore ➾ Ability to install plugins with specific version in TVsCE by @AlirezaHaghshenas in #1827
+* 🧽 Chore ➾ Group Contracts and Artifacts in TreeViews by @AlirezaHaghshenas in #1825
+* 🛠️ Fix ➾ Contextual help test by @michaelkernaghan in #1833
+* 🛠️ Fix ➾ Add better error handling to withTaq binary by @mweichert in #1831
+* 🛠️ Fix ➾ Doc changes by @mweichert in #1837
+* 🧽 Chore ➾ Update flextesa docs by @mweichert in #1839
+* 🛠️ Fix ➾ Added docs for all missing docs except 'generate-project-metadata' and 'pin' by @mweichert in #1840
+* 🛠️ Fix ➾  Closes #1775, ensures that protocol package can be consumed by nodejs, deno, and browsers by @mweichert in #1836
+* 🛠️ Fix ➾ #1750, uninstall plugin emits error by @mweichert in #1821
+* 🛠️ Fix ➾ Dynamically set the column wrapping of the yargs help menu by @mweichert in #1842
+* 🧪 Pre-Release ➾ v0.28.1 (and VSCode v0.29.0) by @mweichert in #1841
+
+** Full Changelog: https://github.com/ecadlabs/taqueria/compare/v0.28.0...v0.28.2
+
+
 ## Taqueria v0.28.2
 | Details     |               |
 | ----------- | ------------- |

--- a/website/docs/release-notes.mdx
+++ b/website/docs/release-notes.mdx
@@ -5,9 +5,9 @@ title: Taqueria Releases
 ## Taqueria v0.28.3
 | Details     |               |
 | ----------- | ------------- |
-|Release Date | Feb 16, 2023  |
+|Release Date | Mar 2, 2023  |
 |Release Type | Minor         |
-|Release Page | [v0.28.2](https://github.com/ecadlabs/taqueria/releases/tag/v0.28.3) |
+|Release Page | [v0.28.3](https://github.com/ecadlabs/taqueria/releases/tag/v0.28.3) |
 
 ### Summary
 


### PR DESCRIPTION
## Taqueria v0.28.3
| Details     |               |
| ----------- | ------------- |
|Release Date | Feb 16, 2023  |
|Release Type | Minor         |
|Release Page | [v0.28.2](https://github.com/ecadlabs/taqueria/releases/tag/v0.28.3) |

### Summary

#### Taquito plugin
- The `transfer` and `deploy` tasks will now retry if an error occured trying to forge or inject an operation. The tasks will be retried until the max timeout is reached (set to 40 seconds by default).
- Add a `--timeout` option to both the `transfer` and `deploy` tasks to adjust the max timeout before giving up on forging and injecting an operation.

#### Flextesa plugin
- Tasks provided by the flextesa plugin no longer require a sandbox name, which is now inferred from the environment. For example, to start a sandbox you would execute `taq start sandbox` instead of `taq start sandbox local`
- Adds a `taq restart sandbox` task to stop and then restart an already-running sandbox. Useful when you adjust baking options.

#### LIGO plugin
- The `taq ligo` command can be used to create files, such as when you execute `taq ligo -c 'init contract --template multisig-jsligo'`. This release fixes a bug where these files would be owned by root.
- Added missing tests to assure that parameter and storage files are handled properly.


### Pull Requests

* 🛠️ Fix ➾ Don't require sandbox name for any task by @mweichert in https://github.com/ecadlabs/taqueria/pull/1844
* 🛠️ Fix ➾ Ensure that files created by ligo/docker aren't owned by root by @mweichert in https://github.com/ecadlabs/taqueria/pull/1845
* 🛠️ Fix ➾ Add restart sandbox task
* 🛠️ Fix ➾ Ensure that all taquito tasks will retry until max timeout elapsed by @mweichert in https://github.com/ecadlabs/taqueria/pull/1847
* 🧽 Chore ➾ add two tests for ligo compile file handling by @michaelkernaghan in https://github.com/ecadlabs/taqueria/pull/1817

** Full Changelog: https://github.com/ecadlabs/taqueria/compare/v0.28.2...0.28.3