### PR TITLE
🛠️ Fix ➾ Ensure that docker ownership of files created by ligo task work on WSLv2

### DIFF
--- a/taqueria-plugin-ligo/ligo.ts
+++ b/taqueria-plugin-ligo/ligo.ts
@@ -4,6 +4,11 @@ import { getLigoDockerImage, LigoOpts as Opts } from './common';
 const getArbitraryLigoCmd = (parsedArgs: Opts, userArgs: string): [string, Record<string, string>] => {
 	const projectDir = process.env.PROJECT_DIR ?? parsedArgs.projectDir;
 	if (!projectDir) throw `No project directory provided`;
+
+	// In all environments I've found that the UID environment variable is set. However, on
+	// Windows / WSLv2, GID isn't available.
+	const owner = process.env.GID ? `${process.env.UID}:${process.env.GID}` : process.env.UID;
+
 	const binary = 'docker';
 	const baseArgs = [
 		'run',
@@ -13,7 +18,7 @@ const getArbitraryLigoCmd = (parsedArgs: Opts, userArgs: string): [string, Recor
 		'-w',
 		'/project',
 		'-u',
-		`${process.env.UID}:${process.env.GID}`,
+		owner,
 		getLigoDockerImage(),
 	];
 	const processedUserArgs = userArgs.split(' ').map(arg => arg.startsWith('\\-') ? arg.substring(1) : arg).filter(arg =>


### PR DESCRIPTION
# 🌮 Taqueria PR

## 🪁 Description

Fixes a problem with file permissions created by docker when invoking the `taq ligo` task in WSLv2 environments.

## 🪂 Pre-Merge Checklist (Definition of Done)

🚦 Required to merge:

- [ ] ⛱️ I have completed this PR template in full and updated the title appropriately
- [ ] ⛵ My code builds cleanly, and I have manually tested the changes
- [ ] 🏄‍♂️ Another team member has built this branch and done manual testing on the change
- [ ] 🏖️ New and existing unit tests pass locally and in CI
- [ ] 🔱 The test plan has been implemented and verified by an SDET
- [ ] 🦀 Automated tests have been written and added to this PR
- [ ] 🐬 I have commented my code, particularly in hard-to-understand areas
- [ ] 🤿 Corresponding changes have been made to all documentation
- [ ] 🐚 Required changes to the VScE have been made
- [ ] 🪸 Required updates to scaffolds have been made
- [ ] 🚢 The release checklist has been completed

## 🛩️ Summary of Changes

Don't assume that GID environment variable exists.