### PR TITLE
fix: update teztnets domain from .xyz to .com

### DIFF
--- a/taqueria-plugin-taquito/common.ts
+++ b/taqueria-plugin-taquito/common.ts
@@ -202,7 +202,7 @@ export const handleOpsError = (err: unknown, env: string): Promise<never> => {
 			const publicKeyHash = result ? result[0] : undefined;
 			if (publicKeyHash) {
 				return sendAsyncErr(
-					`The account ${publicKeyHash} for the target environment, "${env}", may not be funded\nTo fund this account:\n1. Go to https://teztnets.xyz and click "Faucet" of the target testnet\n2. Copy and paste the above key into the wallet address field\n3. Request some Tez (Note that you might need to wait for a few seconds for the network to register the funds)`,
+					`The account ${publicKeyHash} for the target environment, "${env}", may not be funded\nTo fund this account:\n1. Go to https://teztnets.com and click "Faucet" of the target testnet\n2. Copy and paste the above key into the wallet address field\n3. Request some Tez (Note that you might need to wait for a few seconds for the network to register the funds)`,
 				);
 			}
 		}

--- a/taqueria-protocol/types.ts
+++ b/taqueria-protocol/types.ts
@@ -433,7 +433,7 @@ export type ConfigFileV2 = {
 	 * Example environment types:
 	 *
 	 * - a sandbox running locally (using flextesa and taquito plugin)
-	 * - teztnets.xyz (using taquito plugin)
+	 * - teztnets.com (using taquito plugin)
 	 * - mainnet (using taquito plugin with a custom rpcUrl)
 	 *
 	 * The environment implementation also implements the account types that are supported by that environmentType:

--- a/taqueria-sdk/index.ts
+++ b/taqueria-sdk/index.ts
@@ -739,7 +739,7 @@ export const getAccountPrivateKey = async (
 			return sendAsyncErr(
 				`A keypair with public key hash ${
 					network.accounts[account].publicKeyHash
-				} was generated for you.\nTo fund this account:\n1. Go to https://teztnets.xyz and click "Faucet" of the target testnet\n2. Copy and paste the above key into the wallet address field\n3. Request some Tez (Note that you might need to wait for a few seconds for the network to register the funds)`,
+				} was generated for you.\nTo fund this account:\n1. Go to https://teztnets.com and click "Faucet" of the target testnet\n2. Copy and paste the above key into the wallet address field\n3. Request some Tez (Note that you might need to wait for a few seconds for the network to register the funds)`,
 			);
 		}
 	}

--- a/tests/e2e/taquito-plugin-e2e-tests.spec.ts
+++ b/tests/e2e/taquito-plugin-e2e-tests.spec.ts
@@ -244,7 +244,7 @@ describe('Taquito Plugin E2E testing for Taqueria CLI', () => {
 			const { stdout: stdout2, stderr } = deployResult;
 			const result = stdout2.join('\n');
 			expect(result).toMatch(/| Contract\s+| Address\s+| Alias\s+| Balance In Mutez\s+| Destination/);
-			expect(result).toMatch(/hello-tacos.tz\s+| KT[^\|]+| hello-tacos\s+| 0\s+| .+rpc\.ghostnet\.teztnets\.xyz/m);
+			expect(result).toMatch(/hello-tacos.tz\s+| KT[^\|]+| hello-tacos\s+| 0\s+| .+rpc\.ghostnet\.teztnets\.com/m);
 
 			await cleanup();
 		});


### PR DESCRIPTION
The old domain teztnets.xyz has been claimed by a domain squatter and is no longer owned by the project. This commit updates all references to use the new domain teztnets.com.


## 🛸 Type of Change

- [x] 🧽 Chore ➾

