### PR TITLE
Remove duplicated sidebar entries

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -120,11 +120,6 @@ const sidebars = {
         "tasks/deploy",
         "tasks/instantiate-account",
         "tasks/fund",
-        
-        // Taquito plugin tasks
-        "tasks/deploy",
-        "tasks/instantiate-account",
-        "tasks/fund",
 
         // Pinata plugin tasks
         "tasks/publish",


### PR DESCRIPTION
The docs have three duplicated sidebar entries that go to the same page, as shown here. This PR removes them:

<img width="244" height="365" alt="Screenshot 2025-08-21 at 2 38 05 PM" src="https://github.com/user-attachments/assets/0c1ca67c-5c6b-4fa1-ba67-00619b119d93" />
